### PR TITLE
Create a sandbox ns & enforce rbac for gitlab-runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ build/test-pkg-deps: | build ## Build package dependencies for testing
 	build/zarf package create utils/pkg-deps/gitlab/postgres/ --skip-sbom --confirm --output-directory build
 	build/zarf package create utils/pkg-deps/gitlab/redis/ --skip-sbom --confirm --output-directory build
 	build/zarf package create utils/pkg-deps/gitlab/minio/ --skip-sbom --confirm --output-directory build
+	build/zarf package create utils/pkg-deps/gitlab-runner/ --skip-sbom --confirm --output-directory build
 	build/zarf package create utils/pkg-deps/sonarqube/postgres/ --skip-sbom --confirm --output-directory build
 
 build/uds-package-software-factory: | build ## Build the software factory
@@ -193,6 +194,7 @@ deploy/test-pkg-deps: ## Deploy the package dependencies needed for testing the 
 	cd ./build && ./zarf package deploy zarf-package-gitlab-postgres-* --confirm
 	cd ./build && ./zarf package deploy zarf-package-gitlab-redis-* --confirm
 	cd ./build && ./zarf package deploy zarf-package-gitlab-minio-* --confirm
+	cd ./build && ./zarf package deploy zarf-package-gitlab-runner-* --confirm
 	cd ./build && ./zarf package deploy zarf-package-sonarqube-postgres-* --confirm
 
 deploy/uds-package-software-factory: ## Deploy the software factory package

--- a/README.md
+++ b/README.md
@@ -73,6 +73,44 @@ Object Storage works a bit differently as there are many kinds of file stores gi
   - runner-cache
   - tmp
 
+### GitLab-Runner Capability
+The Gitlab-Runner Capability expects the pieces listed below to exist in the cluster before being deployed.
+
+#### General
+
+- Create `gitlab-runner-sandbox` namespace
+- Label `gitlab-runner-sandbox` namespace with `istio-injection: enabled` & `zarf.dev/agent: ignore`
+- Create an `rbac` file for the `gitlab-runner` service account
+
+#### RBAC file
+
+- The `rbac.yaml` should create a `ClusterRole` with the following values:
+```
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "pods", "pods/attach", "secrets", "services"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "patch", "delete"]
+```
+- The `ClusterRole` should then be bound using a `RoleBinding` in the `gitlab-runner-sandbox` namespace to the service account that `gitlab-runner` uses
+example:
+```
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitlab-runner-sandbox
+  namespace: gitlab-runner-sandbox
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: gitlab-runner
+roleRef:
+  kind: ClusterRole
+  name: gitlab-runner-sandbox
+```
+
 ### SonarQube Capability
 The SonarQube Capability expects the database listed below to exist in the cluster before being deployed.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Object Storage works a bit differently as there are many kinds of file stores gi
   - tmp
 
 ### GitLab-Runner Capability
+
 The Gitlab-Runner Capability expects the pieces listed below to exist in the cluster before being deployed.
 
 #### General

--- a/utils/pkg-deps/gitlab-runner/policy-exceptions/registry.yaml
+++ b/utils/pkg-deps/gitlab-runner/policy-exceptions/registry.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: gitlab-runner-sandbox-registry-exception
+  namespace: gitlab-runner-sandbox
+spec:
+  exceptions:
+  - policyName: restrict-image-registries
+    ruleNames:
+    - validate-registries
+    - autogen-validate-registries
+  - policyName: disallow-image-tags
+    ruleNames:
+    - validate-image-tag
+  match:
+    any:
+    - resources:
+        namespaces:
+        - gitlab-runner-sandbox

--- a/utils/pkg-deps/gitlab-runner/rbac/rbac.yaml
+++ b/utils/pkg-deps/gitlab-runner/rbac/rbac.yaml
@@ -1,0 +1,26 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitlab-runner-sandbox
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "pods", "pods/attach", "secrets", "services"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "patch", "delete"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitlab-runner-sandbox
+  namespace: gitlab-runner-sandbox
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: gitlab-runner
+roleRef:
+  kind: ClusterRole
+  name: gitlab-runner-sandbox

--- a/utils/pkg-deps/gitlab-runner/zarf.yaml
+++ b/utils/pkg-deps/gitlab-runner/zarf.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/main/zarf.schema.json
+kind: ZarfPackageConfig
+metadata:
+  name: gitlab-runner
+  version: "0.0.1"
+  architecture: amd64
+
+components:
+  - name: gitlab-runner-sandbox-kyverno-exception
+    required: true
+    manifests:
+      - name: kyverno-exceptions
+        files:
+          - policy-exceptions/registry.yaml
+  - name: registry1-creds
+    required: true
+    actions:
+      onDeploy:
+        before:
+          - cmd: kubectl delete secret private-registry -n gitlab-runner-sandbox
+        after:
+          - cmd: kubectl create secret generic private-registry --from-file=.dockerconfigjson=$(printf ~/.docker/config.json) --type=kubernetes.io/dockerconfigjson -n gitlab-runner-sandbox

--- a/utils/pkg-deps/gitlab-runner/zarf.yaml
+++ b/utils/pkg-deps/gitlab-runner/zarf.yaml
@@ -12,6 +12,12 @@ components:
       - name: kyverno-exceptions
         files:
           - policy-exceptions/registry.yaml
+  - name: gitlab-runner-sandbox-rbac
+    required: true
+    manifests:
+      - name: gitlab-runner-sandbox-rbac
+        files:
+          - rbac/rbac.yaml
   - name: registry1-creds
     required: true
     actions:

--- a/utils/pkg-deps/namespaces/values.yaml
+++ b/utils/pkg-deps/namespaces/values.yaml
@@ -11,6 +11,10 @@ namespaces:
   - name: gitlab-minio
     labels:
       istio-injection: enabled
+  - name: gitlab-runner-sandbox
+    labels:
+      istio-injection: enabled
+      zarf.dev/agent: ignore
   - name: sonarqube
     labels:
       istio-injection: enabled

--- a/values/gitlab-runner.yaml
+++ b/values/gitlab-runner.yaml
@@ -62,15 +62,5 @@ runners:
         "job_name" = "${CI_JOB_NAME}"
         "pipeline_id" = "${CI_PIPELINE_ID}"
 
-
-# Look at this later for user CI
 rbac:
-  create: true
-  clusterWideAccess: true
-  rules:
-  - resources: ["configmaps", "pods", "pods/attach", "secrets", "services"]
-    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["pods/exec"]
-    verbs: ["create", "patch", "delete"]
-
+  create: false

--- a/values/gitlab-runner.yaml
+++ b/values/gitlab-runner.yaml
@@ -48,18 +48,29 @@ runners:
     # bigbang package-images.yaml says its using 8.8 but gitlab-runner is actually using 8.7. Forcing it to use 8.8
     # since the capability is pulling that in based on bigbang package-images.yaml
     tag: "8.8"
+  config: |
+    [[runners]]
+      clone_url = "http://gitlab-webservice-default.gitlab.svc.cluster.local:8181"
+      cache_dir = "/tmp/gitlab-runner/cache"
+      [runners.kubernetes]
+        namespace = "gitlab-runner-sandbox"
+        image = "{{ printf "%s/%s:%s" .Values.runners.job.registry .Values.runners.job.repository .Values.runners.job.tag }}"
+        helper_image = "{{ printf "%s/%s:%s" .Values.runners.helper.registry .Values.runners.helper.repository .Values.runners.helper.tag }}"
+        image_pull_secrets = ["private-registry"]
+      [runners.kubernetes.pod_labels]
+        "job_id" = "${CI_JOB_ID}"
+        "job_name" = "${CI_JOB_NAME}"
+        "pipeline_id" = "${CI_PIPELINE_ID}"
 
-# runners:
-#   config: |
-#     [[runners]]
-#       [runners.kubernetes]
-#         image = "registry1.dso.mil/ironbank/redhat/ubi/ubi8:8.8"
-#         [runners.kubernetes.pod_labels]
-#           "job_id" = "${CI_JOB_ID}"
-#           "job_name" = "${CI_JOB_NAME}"
-#           "pipeline_id" = "${CI_PIPELINE_ID}"
 
 # Look at this later for user CI
-# rbac:
-#   create: true
-#   clusterWideAccess: true
+rbac:
+  create: true
+  clusterWideAccess: true
+  rules:
+  - resources: ["configmaps", "pods", "pods/attach", "secrets", "services"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "patch", "delete"]
+

--- a/values/sonarqube.yaml
+++ b/values/sonarqube.yaml
@@ -25,6 +25,15 @@ networkPolicies:
 networkPolicy:
   enabled: true
   additionalNetworkPolicys:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            app.kubernetes.io/name: gitlab-runner-sandbox
+        podSelector: {}
+      ports:
+      - port: 9000
+        protocol: TCP
     egress:
     - to:
       - namespaceSelector:
@@ -33,10 +42,16 @@ networkPolicy:
         podSelector:
           matchLabels:
             app: webservice
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            app.kubernetes.io/name: gitlab-runner-sandbox
+        podSelector: {}
     podSelector:
       matchLabels: {}
     policyTypes:
     - Egress
+    - Ingress
 
 image:
   pullPolicy: IfNotPresent

--- a/values/sonarqube.yaml
+++ b/values/sonarqube.yaml
@@ -29,7 +29,7 @@ networkPolicy:
     - from:
       - namespaceSelector:
           matchLabels:
-            app.kubernetes.io/name: gitlab-runner-sandbox
+            kubernetes.io/metadata.name: gitlab-runner-sandbox
         podSelector: {}
       ports:
       - port: 9000
@@ -38,14 +38,14 @@ networkPolicy:
     - to:
       - namespaceSelector:
           matchLabels:
-            app.kubernetes.io/name: gitlab
+            kubernetes.io/metadata.name: gitlab
         podSelector:
           matchLabels:
             app: webservice
     - to:
       - namespaceSelector:
           matchLabels:
-            app.kubernetes.io/name: gitlab-runner-sandbox
+            kubernetes.io/metadata.name: gitlab-runner-sandbox
         podSelector: {}
     podSelector:
       matchLabels: {}


### PR DESCRIPTION
- Made a sandbox namespace for the gitlab-runner job pods to use that isn't restricted by zarf
- Added some RBAC to gitlab-runner to restrict some of its capabilities