### PR TITLE
feat: Initial component generator

### DIFF
--- a/.github/actions/lula/action.yaml
+++ b/.github/actions/lula/action.yaml
@@ -1,0 +1,23 @@
+name: Lula
+
+description: Runs Lula Lint to validate OSCAL Schema
+
+inputs:
+  oscal-path:
+    description: Path to OSCAL
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Update GitHub status for pending pipeline run
+    - name: Install Lula
+      shell: bash -e -o pipefail {0}
+      run: |
+        curl -L -o lula "https://github.com/defenseunicorns/lula/releases/download/v0.0.1/lula_v0.0.1_Linux_amd64"
+        chmod +x lula
+    
+    - name: Lula Lint
+      shell: bash -e -o pipefail {0}
+      run: | 
+        ./lula tools lint -f ${{  inputs.oscal-path  }}

--- a/.github/workflows/create-oscal-component.yaml
+++ b/.github/workflows/create-oscal-component.yaml
@@ -56,6 +56,14 @@ jobs:
           rm package.json
           rm package-lock.json
 
+      - name: Lula Setup
+        uses: defenseunicorns/lula-action/setup@095636b7880051e11b05f10a582fdd911526161c # Commit Tag
+
+      - name: Lula Lint
+        uses: defenseunicorns/lula-action/lint@095636b7880051e11b05f10a582fdd911526161c # Commit Tag
+        with:
+          oscal-target: "oscal-component.yaml"
+
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
         with:

--- a/.github/workflows/create-oscal-component.yaml
+++ b/.github/workflows/create-oscal-component.yaml
@@ -1,0 +1,62 @@
+name: CI SWF OSCAL
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - ".gitignore"
+      - "LICENSE"
+      - "**/*.md"
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  create-and-update-swf-oscal:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+
+      - name: Uses Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.20"
+
+      - name: Node and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+
+      - name: Download Component Generator
+        run: |
+          git clone https://github.com/defenseunicorns/component-generator.git
+          cd component-generator/
+          make build
+          cd ..
+
+      - name: Create SWF OSCAL-Component File
+        run: ./component-generator/bin/component-generator aggregate --input .github/workflows/oscal/config-swf-oscal-component.yaml
+
+      - name: Clean Up
+        run: rm -rf component-generator
+
+      - name: Yaml Formatter and Cleanup
+        run: |
+          npm install --save-dev --save-exact prettier
+          npx prettier oscal-component.yaml --write
+          npm uninstall --save-dev prettier
+          rm -rf node_modules/
+          rm package.json
+          rm package-lock.json
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          skip_checkout: true

--- a/.github/workflows/create-oscal-component.yaml
+++ b/.github/workflows/create-oscal-component.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Uses Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: latest
+          go-version: stable
 
       - name: Node and NPM
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1

--- a/.github/workflows/create-oscal-component.yaml
+++ b/.github/workflows/create-oscal-component.yaml
@@ -19,18 +19,18 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.head_ref }}
 
 
       - name: Uses Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.20"
+          go-version: latest
 
       - name: Node and NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: latest
 
@@ -57,6 +57,6 @@ jobs:
           rm package-lock.json
 
       - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
         with:
           skip_checkout: true

--- a/.github/workflows/lula-lint.yaml
+++ b/.github/workflows/lula-lint.yaml
@@ -16,20 +16,19 @@ on:
       - "oscal-component.yaml"
 
 jobs:
-  pull:
+  lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the repo and setup the tooling for this job
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
-  lint:
-    runs-on: ubuntu-latest
-    needs: pull
-    steps:
+      - name: Lula Setup
+        uses: defenseunicorns/lula-action/setup@095636b7880051e11b05f10a582fdd911526161c # Commit Tag
+
       - name: Lula Lint
-        uses: ./.github/actions/lula
+        uses: defenseunicorns/lula-action/lint@095636b7880051e11b05f10a582fdd911526161c # Commit Tag
         with:
-          oscal-path: "/uds-package-software-factory/oscal-component.yaml"
+          oscal-target: "oscal-component.yaml"

--- a/.github/workflows/lula-lint.yaml
+++ b/.github/workflows/lula-lint.yaml
@@ -1,0 +1,35 @@
+name: lula-lint
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    # We need -e -o pipefail for consistency with GitHub Actions' default behavior
+    shell: bash -e -o pipefail {0}
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "oscal-component.yaml"
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repo and setup the tooling for this job
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: pull
+    steps:
+      - name: Lula Lint
+        uses: ./.github/actions/lula
+        with:
+          oscal-path: "/uds-package-software-factory/oscal-component.yaml"

--- a/.github/workflows/oscal/config-swf-oscal-component.yaml
+++ b/.github/workflows/oscal/config-swf-oscal-component.yaml
@@ -1,0 +1,30 @@
+name: ./oscal-component.yaml # Name of the generated file
+metadata: # OSCAL-compliant metadata
+  title: UDS Package Software Factory
+  version: 0.0.1
+  oscal-version: 1.1.1
+  parties:
+    - uuid: f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+      name: Defense Unicorns
+      links:
+        - href: https://defenseunicorns.com
+          rel: website
+      type: organization
+components: # Define paths on the local filesystem or remote paths in git repositories to OSCAL component definition files
+  remote:
+    - git: https://github.com/defenseunicorns/uds-package-dubbd@v0.14.0
+      path: ./defense-unicorns-distro/oscal-component.yaml
+    - git: https://github.com/defenseunicorns/uds-capability-gitlab@v0.1.8
+      path: oscal-component.yaml
+    - git: https://github.com/defenseunicorns/uds-capability-gitlab-runner@v0.1.2
+      path: oscal-component.yaml
+    - git: https://github.com/defenseunicorns/uds-capability-sonarqube@v0.1.2
+      path: oscal-component.yaml
+    - git: https://github.com/defenseunicorns/uds-capability-jira@v0.1.3
+      path: oscal-component.yaml
+    - git: https://github.com/defenseunicorns/uds-capability-confluence@v0.1.3
+      path: oscal-component.yaml
+    - git: https://github.com/defenseunicorns/uds-capability-mattermost-operator@v0.1.3
+      path: oscal-component.yaml
+    - git: https://github.com/defenseunicorns/uds-capability-nexus@v0.1.2
+      path: oscal-component.yaml

--- a/.github/workflows/oscal/config-swf-oscal-component.yaml
+++ b/.github/workflows/oscal/config-swf-oscal-component.yaml
@@ -12,19 +12,19 @@ metadata: # OSCAL-compliant metadata
       type: organization
 components: # Define paths on the local filesystem or remote paths in git repositories to OSCAL component definition files
   remote:
-    - git: https://github.com/defenseunicorns/uds-package-dubbd@v0.14.0
+    - git: https://github.com/defenseunicorns/uds-package-dubbd@v0.16.0
       path: ./defense-unicorns-distro/oscal-component.yaml
-    - git: https://github.com/defenseunicorns/uds-capability-gitlab@v0.1.8
+    - git: https://github.com/defenseunicorns/uds-capability-gitlab@v0.1.15
       path: oscal-component.yaml
-    - git: https://github.com/defenseunicorns/uds-capability-gitlab-runner@v0.1.2
+    - git: https://github.com/defenseunicorns/uds-capability-gitlab-runner@v0.1.3
       path: oscal-component.yaml
-    - git: https://github.com/defenseunicorns/uds-capability-sonarqube@v0.1.2
+    - git: https://github.com/defenseunicorns/uds-capability-sonarqube@v0.1.3
       path: oscal-component.yaml
-    - git: https://github.com/defenseunicorns/uds-capability-jira@v0.1.3
+    - git: https://github.com/defenseunicorns/uds-capability-jira@v0.1.5
       path: oscal-component.yaml
-    - git: https://github.com/defenseunicorns/uds-capability-confluence@v0.1.3
+    - git: https://github.com/defenseunicorns/uds-capability-confluence@v0.1.4
       path: oscal-component.yaml
-    - git: https://github.com/defenseunicorns/uds-capability-mattermost-operator@v0.1.3
+    - git: https://github.com/defenseunicorns/uds-capability-mattermost-operator@v0.1.7
       path: oscal-component.yaml
-    - git: https://github.com/defenseunicorns/uds-capability-nexus@v0.1.2
+    - git: https://github.com/defenseunicorns/uds-capability-nexus@v0.1.5
       path: oscal-component.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,10 +80,10 @@ jobs:
         uses: supplypike/setup-bin@v3
         with:
           # renovate: uds-cli-uri datasource=github-tags depName=defenseunicorns/uds-cli
-          uri: 'https://github.com/defenseunicorns/uds-cli/releases/download/v0.5.0/uds-cli_v0.5.0_Linux_amd64 '
+          uri: 'https://github.com/defenseunicorns/uds-cli/releases/download/v0.5.1/uds-cli_v0.5.1_Linux_amd64 '
           name: 'uds'
           # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-          version: 'v0.5.0'
+          version: 'v0.5.1'
 
       - name: Login to GHCR
         uses: docker/login-action@v2
@@ -102,12 +102,13 @@ jobs:
       - name: Build Software Factory Dependencies Packages
         run: |
           mkdir -p build
-          zarf package create packages/idam-dns       --confirm --no-progress --output-directory build
-          zarf package create packages/idam-gitlab    --confirm --no-progress --output-directory build
-          zarf package create packages/idam-sonarqube --confirm --no-progress --output-directory build
-          zarf package create packages/idam-realm     --confirm --no-progress --output-directory build
-          zarf package create packages/idam-postgres  --confirm --no-progress --output-directory build
-          zarf package create packages/namespaces     --confirm --no-progress --output-directory build
+          zarf package create packages/idam-dns                          --confirm --no-progress --output-directory build
+          zarf package create packages/idam-gitlab                       --confirm --no-progress --output-directory build
+          zarf package create packages/idam-sonarqube                    --confirm --no-progress --output-directory build
+          zarf package create packages/idam-realm                        --confirm --no-progress --output-directory build
+          zarf package create packages/idam-postgres                     --confirm --no-progress --output-directory build
+          zarf package create packages/namespaces                        --confirm --no-progress --output-directory build
+          zarf package create packages/additional-kyverno-exceptions     --confirm --no-progress --output-directory build
 
       - name: Build software factory bundle
         run: uds create --confirm --no-progress

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,19 +71,19 @@ jobs:
         uses: supplypike/setup-bin@v3
         with:
           # renovate: zarf-uri datasource=github-tags depName=defenseunicorns/zarf
-          uri: 'https://github.com/defenseunicorns/zarf/releases/download/v0.31.3/zarf_v0.31.3_Linux_amd64'
+          uri: 'https://github.com/defenseunicorns/zarf/releases/download/v0.31.4/zarf_v0.31.4_Linux_amd64'
           name: 'zarf'
           # renovate: datasource=github-tags depName=defenseunicorns/zarf versioning=semver
-          version: 'v0.31.3'
+          version: 'v0.31.4'
 
       - name: Install uds-cli
         uses: supplypike/setup-bin@v3
         with:
           # renovate: uds-cli-uri datasource=github-tags depName=defenseunicorns/uds-cli
-          uri: 'https://github.com/defenseunicorns/uds-cli/releases/download/v0.3.1/uds-cli_v0.3.1_Linux_amd64 '
+          uri: 'https://github.com/defenseunicorns/uds-cli/releases/download/v0.5.0/uds-cli_v0.5.0_Linux_amd64 '
           name: 'uds'
           # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-          version: 'v0.3.1'
+          version: 'v0.5.0'
 
       - name: Login to GHCR
         uses: docker/login-action@v2

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # The version of Zarf to use. To keep this repo as portable as possible the Zarf binary will be downloaded and added to
 # the build folder.
 # renovate: datasource=github-tags depName=defenseunicorns/zarf
-UDS_CLI_VERSION := v0.4.0
+UDS_CLI_VERSION := v0.5.1
 
-ZARF_VERSION := v0.31.3
+ZARF_VERSION := v0.31.4
 
 # The version of the build harness container to use
 BUILD_HARNESS_REPO := ghcr.io/defenseunicorns/build-harness/build-harness
 # renovate: datasource=docker depName=ghcr.io/defenseunicorns/build-harness/build-harness
-BUILD_HARNESS_VERSION := 1.14.2
+BUILD_HARNESS_VERSION := 1.14.8
 
 # Figure out which Zarf binary we should use based on the operating system we are on
 ZARF_BIN := zarf
@@ -140,7 +140,7 @@ cluster/destroy: ## Destroy the k3d cluster
 ########################################################################
 
 .PHONY: build/all
-build/all: build build/zarf build/uds build/software-factory-namespaces build/idam-dns build/idam-realm build/idam-postgres build/idam-gitlab build/idam-sonarqube build/uds-bundle-software-factory ## Build everything
+build/all: build build/zarf build/uds build/software-factory-namespaces build/idam-dns build/idam-realm build/idam-postgres build/idam-gitlab build/idam-sonarqube build/additional-kyverno-exceptions build/uds-bundle-software-factory ## Build everything
 
 build: ## Create build directory
 	mkdir -p build
@@ -180,6 +180,9 @@ build/idam-realm: | build ## Build idam-realm package
 
 build/idam-postgres: | build ## Build idam-postgres package
 	cd build && ./zarf package create --skip-sbom ../packages/idam-postgres/ --confirm --output-directory .
+
+build/additional-kyverno-exceptions: | build ## Build additional-kyverno-exceptions package
+	cd build && ./zarf package create --skip-sbom ../packages/additional-kyverno-exceptions/ --confirm --output-directory .
 
 build/uds-bundle-software-factory: | build ## Build the software factory
 	cd build && ./uds create ../ --confirm

--- a/oscal-component.yaml
+++ b/oscal-component.yaml
@@ -1,0 +1,2052 @@
+component-definition:
+  uuid: 506765e1-ba26-43df-bc3e-e03ed98336df
+  metadata:
+    version: 0.0.1
+    parties:
+      - type: organization
+        name: Defense Unicorns
+        uuid: f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+        links:
+          - rel: website
+            href: https://defenseunicorns.com
+    last-modified: "2024-01-10T17:59:16Z"
+    oscal-version: 1.1.1
+    title: UDS Package Software Factory
+  components:
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description: Controls implemented by authservice for inheritance by applications
+          implemented-requirements:
+            - uuid: 6EC9C476-9C9D-4EF6-854B-A5B799D8AED1
+              control-id: si-4.10
+              description:
+                Kiali provides visibility into mTLS settings of all Istio traffic
+                in the cluster.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: A97D1364-BA7F-46AA-ADE6-1998E846E125
+      title: Kiali
+      description: |
+        A management console for Istio Service Mesh
+      type: software
+      purpose: Observibility into Istio Service Mesh
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - 72134592-08C2-4A77-ABAD-C880F109367A
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description: Controls implemented by Tempo for inheritance by applications
+          implemented-requirements:
+            - uuid: 3C102ED9-4CE5-4AB1-ABE5-78426DF15BBE
+              control-id: au-4
+              description: Uses scalable object storage to allocate audits logs.
+            - uuid: 9904027A-28A8-4808-8617-D0DD29BF9B8B
+              control-id: au-12.1
+              description: Provides a time-series event compilation audit trail capabilities.
+            - uuid: D0EE25CB-DAA8-4298-BBB9-A5AC72034020
+              control-id: si-4.4
+              description:
+                Jaeger is used, in conjunction with Istio configurations, to
+                collect and aggregate network communications within the system.  This allows
+                the monitoring of inbound/outbound traffic and payloads within the deployed
+                environment.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: AE3E8F16-D93B-4594-82A3-5DA38AC066BF
+      title: Tempo
+      description: |
+        Grafana Tempo is an open source, easy-to-use, and high-scale distributed tracing backend
+      type: software
+      purpose: Implementation of Service Mesh
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - 72134592-08C2-4A77-ABAD-C880F109367A
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description: Controls implemented by authservice for inheritance by applications.
+          implemented-requirements:
+            - uuid: B5B39044-B02A-4655-B466-7586B24963A1
+              control-id: ac-6.9
+              description:
+                "Privileged events, including updating the deployment of an application,
+                or use of privileged containers are collected as metrics by prometheus and
+                displayed by Grafana. "
+            - uuid: 8AE237CE-E7FF-42FE-B79F-2DF106B0CC09
+              control-id: au-2
+              description:
+                "API endpoints suitable for capturing application level metrics
+                are present on each of the supported applications running as containers.
+                In addition, system and cluster level metrics are emitted by containers
+                with read only access to host level information. Metrics are captured and
+                stored by Prometheus, an web server capable of scraping endpoints formatted
+                in the appropriate dimensional data format. Metrics information is stored
+                on disk in a time series data base, and later queried through a separate
+                component providing a web interface for the query language: PromQL. "
+            - uuid: F2FFC2FD-6826-43EE-9922-705A76FE63CC
+              control-id: au-3.1
+              description:
+                Grafana has pre-configured dashboards showing the audit records
+                from Cluster Auditor saved in Prometheus.
+            - uuid: B958C179-EE1F-40FC-BA2A-03B0072B20E6
+              control-id: au-4
+              description:
+                Prometheus is the log aggregator for audit logs since it is used
+                to scrape/collect violations from ClusterAuditor. The storage capability
+                can be configured in prometheus to use PVCs to ensure metrics have log retention
+                compliance with the org-defined audit-log retention requirements.
+            - uuid: FA95745B-E13E-4153-ABEE-1970C315A381
+              control-id: au-5.1
+              description:
+                Alertmanager has pre-built alerts for PVC storage thresholds
+                that would fire for PVCs supporting prometheus metrics storage.
+            - uuid: 5D45F4A3-A37F-451D-9670-8FA9DFD1355F
+              control-id: au-5.2
+              description:
+                Alertmanager has pre-build alerts for failed pods that would
+                show when ClusterAuditor is not processing events, or prometheus is unable
+                to scrape events. Prometheus also has a deadman's alert to ensure end users
+                are seeing events from prometheus as part of its configuration.
+            - uuid: 603A45C9-E730-4321-B8AE-60D048E14BAB
+              control-id: au-6.1
+              description:
+                Cluster Audtitor Events/Alerts could be exported from Prometheus
+                to an external system. Integration for specific tooling would need to be
+                completed by end user.
+            - uuid: 92D322C1-B4D3-4842-8B06-538218AECA7D
+              control-id: au-6.3
+              description:
+                Aggregating cluster auditor events across multiple sources (clusters)
+                is possible with a multi-cluster deployment of prometheus/grafana.
+            - uuid: BB0DF859-827F-4E3A-8C61-DEDCE4A9B3EB
+              control-id: au-6.5
+              description:
+                Cluster Auditor's audit data is consolidated with system monitoring
+                tooling (node exporters) for consolidated view to enhance inappropriate
+                or unusual activity.
+            - uuid: 77C00727-4195-45A8-8BB6-534AE5889E71
+              control-id: au-6.6
+              description:
+                Cluster Auditor data in prometheus would enable this, but would
+                require prometheus to also obtain access to physical metrics.
+            - uuid: 6F291DF6-5613-46DF-9D9A-AC7CEDFF4A7B
+              control-id: au-7
+              description:
+                Grafana is configured with a pre-built dashboard for policy violations
+                that displays data collected by Cluster Auditor.
+            - uuid: 54D583CE-DB4A-4C03-902D-9A37949F4820
+              control-id: au-7.1
+              description:
+                Grafana is configured with a pre-built dashboard for policy violations
+                that displays data collected by Cluster Auditor.
+            - uuid: 91D9D559-1666-420B-9F2B-240BC7CD1A3E
+              control-id: au-8
+              description:
+                Prometheus stores all data as time-series data, so the timestamps
+                of when those violations were present is part of the data-stream.
+            - uuid: 2D7AB4A4-1AE7-45A6-BC56-9FBB6402AD98
+              control-id: au-9
+              description:
+                Grafana has the ability to provide Role Based Access Control
+                to limit the data sources that end users can view by leveraging an identity
+                provider. Grafana can also limit users to subsets of metrics within a datasource
+                by the use of Label Based Access Control when using Grafana Enterprise.
+            - uuid: 58B88EBD-ABAD-4505-9243-809D8DEFAEF7
+              control-id: au-9.2
+              description:
+                Prometheus can scrape external components outside of the system,
+                but this configuration is not easily supported as part of the current big
+                bang configuration of ClusterAuditor since external access to ClusterAuditor
+                metrics is not exposed via Istio.
+            - uuid: 8178202C-6E6C-415A-8B0D-C486AAC85B3A
+              control-id: au-9.4
+              description:
+                Grafana has the ability to provide Role Based Access Control
+                to limit the data sources that end users can view by leveraging an identity
+                provider. Grafana can also limit users to subsets of metrics within a datasource
+                by the use of Label Based Access Control when using Grafana Enterprise.
+            - uuid: A471F648-C22C-4217-A3BA-1063E80B4BA3
+              control-id: au-12.1
+              description:
+                Compatible metrics endpoints emitted from each application is
+                compiled by Prometheus and displayed through Grafana with associated timestamps
+                of when the data was collected
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: 4045FB97-C11A-4F3B-A021-FD94538F0356
+      title: Monitoring
+      description: |
+        Aggregator of policy violations in environment
+      type: software
+      purpose: Display policy violations
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - 72134592-08C2-4A77-ABAD-C880F109367A
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description: Controls implemented by NeuVector for inheritance by applications
+          implemented-requirements:
+            - uuid: 7d524c68-a463-4283-9f50-a4f914b0feb9
+              control-id: ac-2
+              description:
+                "NeuVector supports internal user accounts and roles in addition
+                to LDAP and SSO for providing RBAC access. "
+            - uuid: c32ebef9-831b-4662-9172-7cec6697b1e5
+              control-id: ac-2.1
+              description:
+                "NeuVector supports internal user accounts and roles in addition
+                to LDAP and SSO for providing RBAC access. "
+            - uuid: 56ab01ce-a2eb-4a9b-9e77-4b598c0c9230
+              control-id: ac-3
+              description:
+                "NeuVector supports internal user accounts and roles in addition
+                to LDAP and SSO for providing RBAC access. "
+            - uuid: de3fa1f1-b7ce-43a4-97c7-53a15f9dadaf
+              control-id: ac-6
+              description:
+                "NeuVector supports mapping internal user accounts and roles
+                in addition to LDAP and SSO roles or groups for providing RBAC access. "
+            - uuid: 4a200112-0c9b-4fae-a9dd-45c8d9a70886
+              control-id: ac-6.1
+              description:
+                "NeuVector supports mapping internal user accounts and roles
+                in addition to LDAP and SSO roles or groups for providing RBAC access. "
+            - uuid: 37d720fa-d135-49b8-b423-00ad9f77a92d
+              control-id: ac-6.3
+              description:
+                "NeuVector supports mapping internal user accounts and roles
+                in addition to LDAP and SSO roles or groups for providing RBAC access. "
+            - uuid: 107864dd-f3e6-46b5-8004-2c7f717b2426
+              control-id: ac-6.9
+              description: "NeuVector provides logging access related audit events. "
+            - uuid: 88d83b17-b238-48e5-b1d2-f500035c6dc0
+              control-id: ac-6.10
+              description:
+                "NeuVector supports mapping internal user accounts and roles
+                in addition to LDAP and SSO roles or groups for providing RBAC access. "
+            - uuid: 53c7d03b-80f7-42e5-b300-dca43b2b8f05
+              control-id: au-2
+              description: "NeuVector provides logging access related audit events. "
+            - uuid: 4f50b73f-ff6a-4ce0-8139-dbae4f95b0d5
+              control-id: au-3
+              description: "NeuVector provides logging access related audit events. "
+            - uuid: 297107b6-bbe9-44e0-a36a-e5d7798f8ddd
+              control-id: au-4
+              description:
+                NeuVector can scale elastically based upon actual workload demands
+                to allocate audit log storage capacity.
+            - uuid: 510ce893-a40a-4bf4-92e0-1f1b1cd7d7a4
+              control-id: ca-2.2
+              description:
+                NeuVector continually monitors kubernetes environments and container
+                images to detect misconfigurations, advanced network threats, and vulnerable
+                hosts with all attempts to exploit a vulnerability is documented.
+            - uuid: 15d6de3a-14ef-4efd-ab27-329a9adc4979
+              control-id: ca-7
+              description:
+                NeuVector continually monitors kubernetes environments and container
+                images to detect misconfigurations, advanced network threats, and vulnerable
+                hosts with all attempts to exploit a vulnerability is documented.
+            - uuid: 5f04cfad-8aac-4809-970c-aca8067533fd
+              control-id: cm-6
+              description:
+                NeuVector is configured using Helm Charts. Default settings can
+                be found.
+            - uuid: f1425616-8ebb-48a9-a774-3d1a20c2d74a
+              control-id: cm-7
+              description:
+                "NeuVector is configured securely and only access to required
+                ports are available. "
+            - uuid: 6f18f2f4-3796-4189-8bfa-57d5b7bb10e7
+              control-id: ra-5
+              description:
+                "NeuVector is Kubernetes and container security tool. NeuVector
+                will scan containers for vulnerabilities in addition to continuous monitoring
+                for active threats. "
+            - uuid: c458f99a-78fd-4322-91e9-034b51f3e414
+              control-id: ra-5.2
+              description:
+                "NeuVector container scanning vulnerability database is updated
+                frequently. "
+            - uuid: 3ae44f3f-b44a-44e6-8752-e494b82e0ded
+              control-id: ra-5.3
+              description: "NeuVector container scanning configurations depth can be modified. "
+            - uuid: 142a0165-16de-4a5b-a151-cc646a5a943c
+              control-id: ra-5.5
+              description:
+                NeuVector supports mapping internal user accounts and roles in
+                addition to LDAP and SSO roles or groups for providing RBAC access.
+            - uuid: 8974dd78-8695-41ed-b68e-92e3105ff414
+              control-id: sa-11
+              description:
+                NeuVector continually monitors kubernetes environments and container
+                images to detect misconfigurations, advanced network threats, and vulnerable
+                hosts with all attempts to exploit a vulnerability is documented.
+            - uuid: 4a59d604-10f9-4407-b062-1661063d760d
+              control-id: sa-11.1
+              description:
+                NeuVector continually monitors kubernetes environments and container
+                images to detect misconfigurations, advanced network threats, and vulnerable
+                hosts with all attempts to exploit a vulnerability is documented.
+            - uuid: 4daa5851-1f8d-41fc-aabe-fafcb97d8b84
+              control-id: sc-7
+              description:
+                NeuVector monitors all communications to external interfaces
+                by only connecting to external networks through managed interfaces and utilizes
+                whitelists and blacklists for rules at Layer 7.
+            - uuid: 16c820af-4216-437c-a5e2-356dde1fb626
+              control-id: sc-8
+              description:
+                Data in transit is protected using a TLS connection and secured
+                between components within the data center using an internal certificate
+                until it is terminated at the application node. This ensures that data in
+                transit is encrypted using SSL.
+            - uuid: 4427e494-9ff4-4b98-8c41-62dbe056a1ac
+              control-id: si-2.3
+              description:
+                NeuVector continually monitors your Kubernetes environments to
+                detect misconfigurations, advanced network threats, and vulnerable hosts
+                with all attempts to exploit a vulnerability is documented.
+            - uuid: 6f165f1a-2f91-4ac6-8eee-fe729a715952
+              control-id: si-4
+              description:
+                NeuVector continually monitors your Kubernetes environments to
+                detect misconfigurations, advanced network threats, and vulnerable hosts
+                with all attempts to exploit a vulnerability is documented.
+            - uuid: e56438e7-b572-450a-b5a9-dc9a4cb93665
+              control-id: si-5
+              description:
+                NeuVector correlates configuration data with user behavior and
+                network traffic to provide context around misconfigurations and threats
+                in the form of actionable alerts.
+            - uuid: 93e508f9-530b-43e6-8fb8-c95b20b7e887
+              control-id: si-6
+              description:
+                NeuVector correlates configuration data and network traffic to
+                provide context around verification in the form of actionable alerts.
+            - uuid: 8392f45f-d74e-4a99-a7bb-d3ba45743b0a
+              control-id: si-11
+              description:
+                NeuVector correlates configuration data and network traffic for
+                error tracking to provide context around misconfigurations and threats in
+                the form of actionable alerts.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: f316b988-dfb0-475c-9f1f-58d35cee9157
+      title: NeuVector
+      description: |
+        NeuVector Full Lifecycle Container Security Platform delivers the only cloud-native security with uncompromising end-to-end protection from DevOps vulnerability protection to automated run-time security, and featuring a true Layer 7 container firewall.
+      type: software
+      purpose:
+        To use Security Scanning and Integrated Compliance and Vulnerability
+        Results, Scanning registries and Serverless Repositories, Cloud Native Firewalls,
+        Displays
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - 72134592-08C2-4A77-ABAD-C880F109367A
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/usnistgov/oscal-content/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json
+          description: Controls implemented by Promtail for inheritance by applications
+          implemented-requirements:
+            - uuid: 1E11CEA9-CE73-45F0-BE08-D16B521B8E7E
+              control-id: ac-6.9
+              description:
+                Promtail can be configured to collect all logs from Kubernetes
+                and underlying operating systems, allowing the aggregation of privileged
+                function calls.
+            - uuid: CF81FA93-D365-42C2-82B1-A24EB92556E5
+              control-id: au-2
+              description: |-
+                Logging daemons are present on each node that BigBang is installed on.  Out of the box, the following events are captured:
+                * all containers emitting to STDOUT or STDERR (captured  by container runtime translating container logs to /var/log/containers) * all kubernetes api server requests  * all events emitted by the kubelet
+            - uuid: 6DDD209A-87A4-48BF-B6B9-5925CC7CF4C3
+              control-id: au-3
+              description: |-
+                Records captured by the logging daemon are enriched to  ensure the following are always present:
+                * time of the event (UTC) * source of event (pod, namespace, container id)
+                Applications are responsible for providing all other information.
+            - uuid: D3F883A0-4531-407F-8802-F8233CD1DEE9
+              control-id: au-8
+              description: |-
+                Records captured by the logging daemon are enriched to  ensure the following are always present:
+                * time of the event (UTC) * source of event (pod, namespace, container id)
+                Applications are responsible for providing all other information.
+          uuid: 0277E054-45DD-404E-A6A9-4E0BF47AC561
+      uuid: 6266DF09-F893-4D44-9823-4486B91D81ED
+      title: Promtail
+      description: |
+        Log collector
+      type: software
+      purpose: Collects logs from the cluster
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - 72134592-08C2-4A77-ABAD-C880F109367A
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description: Controls implemented by Loki for inheritance by applications
+          implemented-requirements:
+            - uuid: DEA798EE-6B68-4BB8-80DE-1BC85952F26C
+              control-id: ac-5
+              description:
+                GEL implements RBAC to define system authorization and separation
+                of duties.
+            - uuid: 642C8714-73E3-4A59-A89A-ACF2A36AAB6D
+              control-id: ac-6
+              description: GEL implements RBAC to employ principle of least privilege.
+            - uuid: 7BA2A7E8-D7AA-4229-8A32-53DE9147B4A8
+              control-id: ac-6.1
+              description: "GEL implements RBAC to employ principle of least privilege. "
+            - uuid: 02388229-428F-4896-92A1-AE93210057EC
+              control-id: ac-6.9
+              description:
+                Privileged events that modify the application are logged in the
+                application itself.
+            - uuid: 1A3EA794-360A-492B-8FEB-EE666FCE2010
+              control-id: ac-6.10
+              description:
+                GEL layers an additional RBAC layer that prohibits non-privileged
+                users from executing privileged functions.
+            - uuid: E3221BCB-EFF6-4E6C-9856-3C228735A7D2
+              control-id: ac-21
+              description:
+                GEL layers an additional RBAC layer that prohibits non-privileged
+                users from executing privileged functions.
+            - uuid: AB29AE94-C867-4BBE-AAB4-8BF21DBD31D9
+              control-id: au-4
+              description: Uses scalable object storage.
+            - uuid: B552D3B6-0C38-4B59-9D97-FB1D748EE8EA
+              control-id: au-6
+              description:
+                Provides audit record query and analysis capabilities. Organization
+                will implement record review and analysis.
+            - uuid: D45A7DA4-A9F9-46CD-AFA4-991824D2BAF5
+              control-id: au-6.1
+              description:
+                Provides audit record query and analysis capabilities. Organization
+                will implement record review and analysis.
+            - uuid: 9CCC7BF3-2710-4E00-BC22-2C272FCEC771
+              control-id: au7.1
+              description: Loki provides an API for retrieving and filtering logs.
+            - uuid: 80BCE3BD-97D2-4525-A80C-4759F3B756AD
+              control-id: au-9
+              description:
+                Access to metrics can be restricted to org-defined personnel
+                behind a private endpoint and not given to mission owners.
+            - uuid: E3771199-CBA3-46D0-8632-F745E9B6BFAE
+              control-id: au-9.2
+              description: Supports any object storage.
+            - uuid: 4D71EA77-3904-4CE4-AFDC-5123C88A8BD7
+              control-id: au-9.4
+              description: Enterprise version (GEL) implements RBAC.
+            - uuid: D75DF925-E6CE-49D8-8AB0-BD07DAF559E9
+              control-id: au-11
+              description:
+                Can configure audit record storage retention policy for defined
+                periods of time via the store(s) Loki is configured to use.
+            - uuid: 0833500E-517A-4F52-BD2F-64DE658E22C4
+              control-id: au-12.1
+              description: Provides time-series event compilation capabilities.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: 991BD5DF-A3E7-42D6-AC4F-9A8D01E96F91
+      title: Loki
+      description: |
+        Deployment of Loki as a lighter weight replacement for elasticsearch
+      type: software
+      purpose: Provides storage and indexing for logs in the cluster
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - 72134592-08C2-4A77-ABAD-C880F109367A
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/usnistgov/oscal-content/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json
+          description:
+            Controls implemented by Istio and authservice that are inherited
+            by applications
+          implemented-requirements:
+            - uuid: 1822457D-461B-482F-8564-8929C85C04DB
+              control-id: ac-3
+              description: |-
+                Istio implements with global configuration.
+                # Control Summary The information system enforces approved authorizations for logical access to information and system resources in accordance with applicable access control policies.
+                # How Istio Helps Istio helps implement access enforcement in two ways: limiting service-to-service access (see AC-4 below), and acting as an enforcement point for end user authentication and authorization (AC-3, this section). - Service to Service Access: Istio provides authenticatable runtime identities for all applications in the mesh in the form of X.509 certificates.
+                  Those certificates are used for encryption in transit as well as authentication of the service's identity.
+                  This authenticated principal can be used for access control of service to service communication via Istio's AuthorizationPolicy.
+                  We cover this in detail in AC-4, Information Flow Enforcement, below.
+                - End User Authentication and Authorization: Istio facilitates end user authentication and authorization in two ways:
+                  1. Istio has native support for JWT authentication and authorization based on JWT claims.
+                     It can be configured to extract a JWT from each request's headers, validate them against issuers and with specific keys, and limit access based on any of the JWT's fields.
+                  2. Istio supports extracting metadata from each request and forwarding it to an external authentication and authorization server.
+                     Istio will enforce the verdict returned by this server, and can attach additional metadata returned by the server (e.g., an internal JWT in place of an external API key).
+
+                The second, end-user authentication and authorization, are the focus of AC-3.
+                It's important to note that Istio does not implement controls for the Kubernetes API server itself, and access to Istio's own runtime resources and configuration needs to be controlled via Kubernetes RBAC at runtime.
+                # Detailed Instructions You'll need to author slightly different configuration depending on if you're doing JWT-based authentication natively in Istio, or if you're using an External Authorization service.
+                ## Configure JWT-based Request Authentication To configure end user authentication via JSON Web Tokens (JWTs), you need to author a RequestAuthentication resource. If all JWTs in your organization are authenticated in the same way (same issuers, audiences, JWKs, etc), or there's a sensible default, then it should be authored in the root namespace (istio-system by default). If every service has a different audience or other fields, then they should author a RequestAuthentication policy specific to their own service in their own namespace. If you have a default in the root namespace, it will be overridden by the policy in the local namespace. ``` apiVersion: security.istio.io/v1beta1 kind: RequestAuthentication metadata: name: jwt-on-ingress namespace: istio-system spec: selector:
+                  matchLabels:
+                    app: istio-ingressgateway
+                jwtRules: - issuer: "example.com"
+                  jwksUri: https://example.com/.well-known/jwks.json
+                ```
+                ## Configure External Authorization per Request Configuring external authorization is a bit more involved as it is assumed there's only a limited number per mesh deployment. You'll need to configure them as part of the Istio installation, in the global mesh options to know about your authorization service. ``` apiVersion: install.istio.io/v1alpha1 kind: IstioOperator metadata: name: controlplane namespace: istio-system spec: # profile: default # ... meshConfig:
+                  # Add the following content to define the external authorizers.
+                  extensionProviders:
+                  - name: "sample-ext-authz-grpc"
+                    envoyExtAuthzGrpc:
+                      service: "ext-authz.foo.svc.cluster.local"
+                      port: "9000"
+                  - name: "sample-ext-authz-http"
+                    envoyExtAuthzHttp:
+                      service: "ext-authz.foo.svc.cluster.local"
+                      port: "8000"
+                      includeRequestHeadersInCheck: ["x-ext-authz"]
+                ``` Then you'll need to configure an AuthorizationPolicy to call your authorization service for every request. Istio's [detailed guide](https://istio.io/latest/docs/tasks/security/authorization/authz-custom/) covers this configuration well. ``` apiVersion: security.istio.io/v1beta1 kind: AuthorizationPolicy metadata: name: ext-authz namespace: app-team-namespace spec: selector:
+                  matchLabels:
+                    app: httpbin
+                action: CUSTOM provider:
+                  # the name of our provider in the mesh config
+                  # we could also use:
+                  # name: sample-ext-authz-http
+                  name: sample-ext-authz-grpc
+                ``` Note: Even though it's named External Authorization and you're authoring an AuthorizationPolicy, this feature can also be used to perform authentication: the configuration allows you to extract arbitrary headers to hand to the server, and allows the server to return arbitrary data to be attached to the request before it is forwarded on, in addition to enforcing any policy decisions the server returns.
+                # BigBang Implementation BigBang ships with configuration to implement external authorization out of the box. The default installation includes a Keycloak-based external authorization server that can be integrated with your existing identity provider to perform authentication as well as authorization of end-user access per request.
+            - uuid: D7717A9B-7604-45EF-8DCF-EE4DF0417F9C
+              control-id: ac-4
+              description: |-
+                Istio implements with mission team configuration
+                # Control Summary The information system enforces approved authorizations for controlling the flow of information within the system and between interconnected systems based on [Assignment: organization-defined information flow control policies].
+                # How does Istio help? Istio encrypts all in-mesh communication at runtime using the service's identity. This provides TLS for all applications in the mesh. If you're using the Tetrate Istio Distribution, then this TLS is FIPS verified. mTLS is configured through the PeerAuthentication resource, and should be set to STRICT to enforce mTLS between all components of the information system.
+                Istio's AuthorizationPolicy controls service-to-service communication within the mesh. Combined with Istio ingress and egress gateways, as well as a few installation settings, Istio can manage all traffic into and out of your deployment.
+                In addition to AuthorizationPolicies controlling traffic in the mesh, Istio ingress gateways terminate HTTPS on behalf of applications in the mesh (AC-4 (4) - not required by moderate but valuable nonetheless). By managing how traffic flows out of applications using VirtualServices or ServiceEntries, all traffic leaving your infrastructure can be channeled through an egress gateway. Egress gateways can audit and limit how traffic flows to external services outside of the information system under control.
+                While Istio is sufficient for runtime security, most organizations will adopt a defense in depth approach that includes firewalls for inbound and outbound traffic. These firewalls should only allow ingress into Istio control ingress gateways, and only allow egress from Istio-controlled egress gateways. Further, many organizations will augment mesh authorization policy with L3/L4 network segmentation, e.g. with Kubernetes CNI; this is a good practice.
+                # Detailed Instructions
+                ## Enable Authentication Within the mesh, encryption in transit is enforced with a PeerAuthentication resource. A single resource should be authored in the root config namespace (istio-system by default) which sets mTLS Mode to STRICT, enforcing mTLS for all workloads in the mesh. ``` apiVersion: security.istio.io/v1beta1 kind: PeerAuthentication metadata:
+                  name: enforce-mtls
+                  namespace: istio-system
+                spec:
+                  mtls:
+                    mode: STRICT
+                ```
+                ## Configure Service-to-Service Authorization Each service should write an [AuthorizationPolicy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) restricting communication to that service. At a minimum, the AuthorizationPolicy configuration should list a set of principals allowed to communicate with it via an Access Control List (ACL) in the "from" section of the policy. Ideally it should specify specific actions allowed by each group of principals in the "to" section of the policy. If you're using JWT-based user authentication, then the policy should additionally restrict access based on that user credential in the "when" section of the policy. ``` apiVersion: security.istio.io/v1beta1 kind: AuthorizationPolicy metadata:
+                  name: minimum-policy # an ACL
+                  namespace: foo
+                spec:
+                  action: ALLOW
+                  rules:
+                  - from:
+                    - source:
+                      principals:
+                      - "cluster.local/ns/default/sa/sleep"
+                      - "cluster.local/ns/backend/sa/backend"
+                ``` ``` apiVersion: security.istio.io/v1beta1 kind: AuthorizationPolicy metadata:
+                  name: good-policy
+                  namespace: foo
+                spec:
+                  action: ALLOW
+                  rules:
+                  - from:
+                    - source:
+                        principals: ["cluster.local/ns/default/sa/sleep"]
+                    - source:
+                        namespaces: ["test"]
+                    to:
+                    - operation:
+                        methods: ["GET"]
+                        paths: ["/info*"]
+                    - operation:
+                        methods: ["POST"]
+                        paths: ["/data"]
+                    when:
+                    - key: request.auth.claims[iss]
+                      values: ["https://accounts.google.com"]
+                ```
+                ## Forbid Communication to Unknown Services Istio's documentation covers [controlling traffic to external services in detail](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-control/). In short, we should configure the Istio installation to support only services in the registry at installation time. That way, when applications attempt to communicate with unknown services, Istio drops the traffic. This is configured in the mesh config at install time: ``` apiVersion: install.istio.io/v1alpha1 kind: IstioOperator metadata:
+                  name: controlplane
+                  namespace: istio-system
+                spec:
+                  # profile: default
+                  # ...
+                  meshConfig:
+                    # Only allow outbound traffic to known services
+                    outboundTrafficPolicy: REGISTRY_ONLY
+                ``` To enable communication to those services again, we need to author a ServiceEntry - which defines the service in Istio's registry. ``` apiVersion: networking.istio.io/v1alpha3 kind: ServiceEntry metadata:
+                  name: google
+                spec:
+                  hosts:
+                  - www.google.com
+                  ports:
+                  - number: 443
+                    name: https
+                    protocol: HTTPS
+                  resolution: DNS
+                  location: MESH_EXTERNAL
+                ```
+                ## Control Egress Traffic For extra security, or to interact with outbound firewalls, we can force outbound traffic in Istio to go through a dedicated egress proxy. These proxies can be deployed on specific hosts to interact gracefully with traditional outbound firewalls if needed.
+                To force traffic to an external service through the egress gateways, it's best to use a VirtualService combined with a slight modification to the ServiceEntry in the previous example. The service entry will force traffic in the mesh trying to reach the external service through the mesh's egress gateways. The updated ServiceEntry ensures that only the egress gateways are able to resolve the real address of the external service.
+                ``` apiVersion: networking.istio.io/v1alpha3 kind: ServiceEntry metadata:
+                  name: google-external
+                  namespace: istio-system # namespace of your egress proxy
+                spec:
+                  hosts:
+                  - www.google.com
+                  exportTo:
+                  # only the local namespace can resolve google.com to a DNS address
+                  - "."
+                  ports:
+                  - number: 443
+                    name: https
+                    protocol: HTTPS
+                  resolution: DNS
+                  location: MESH_EXTERNAL
+                --- apiVersion: networking.istio.io/v1alpha3 kind: VirtualService metadata:
+                  name: google-egress
+                  namespace: istio-system # default config goes in Istio system
+                spec:
+                  hosts:
+                  - www.google.com
+                  gateways:
+                  - mesh # only apply to sidecars, not the egress gateway
+                  tls:
+                  - match:
+                    - port: 443
+                      sniHosts:
+                      - google.com
+                    route:
+                    - destination:
+                        host: istio-egressgateways.istio-system
+                ```
+                # BigBang Implementation BigBang's default configuration deploys Istio-controlled ingress gateways and forces outbound traffic through egress proxies. So long as your developers write authorization policy for communication of the applications they deploy inside of the cluster, you comply with AC-4.
+            - uuid: 1D1E8705-F6EB-4A21-A24F-1DF7427BA491
+              control-id: ac-4.4
+              description: |-
+                All encrypted HTTPS connections are terminated at the istio ingress gateway.
+                AC-4.4 is not required for FedRAMP Moderate.
+            - uuid: 366AAE60-AC24-4F48-BF63-4C0EB496CC9E
+              control-id: ac-4.21
+              description: |-
+                Istio implements with mission team configuration
+                # Control Summary The information system separates information flows logically or physically using [Assignment: organization-defined mechanisms and/or techniques] to accomplish [Assignment: organization- defined required separations by types of information].
+                ## Comments Pursuing a zero trust architecture, we want to enable logical separation of information flows at as fine-grained a level as possible (per request, based on the full metadata of that request including protocol, verb, source and destination information, and more). Istio enables this, enforcing these policies at the application instance itself (in Kubernetes, the pod) rather than at a gateway.
+                # How does Istio help? When Istio is configured as above for AC-4 – limiting access to services within the information system and controlling communication ingress and egress to and from the information system – it provides logical separation of information flows. Istio policies can provide this separation at the finest grain possible. For example, for HTTP traffic, Istio provides the ability to limit communication per verb and path, as well as based on header values or end-user credentials stored at headers, in addition to controlling traffic with the traditional network five-tuple. Istio enforces the policy at the application instance itself.
+                However, while Istio offers the tools to create logical separation of information flows, it cannot define the required separations itself. Your authorization policies must align with your organization's goals and your application's data. This should be implemented in human review processes as part of implementing this infrastructure as code, and augmented with tooling as part of continuous integration (e.g. [istioctl analyze](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl-analyze/), or vendor tooling like [tctl analyze](https://docs.tetrate.io/service-bridge/1.4.x/en-us/reference/cli/reference/experimental#tctl-experimental-verify)).
+                # Detailed Instructions See examples in AC-4 above to configure runtime encryption as well as access control policies for services in the mesh as well as controlling how services communicate with dependencies outside of the information system.
+                # BigBang Implementation So long as you're authoring service-to-service access policies for applications in the cluster, BigBang's default deployment satisfies these requirements.
+            - uuid: CD1315BF-91FE-490A-B6A6-5616690D78A8
+              control-id: ac-6.3
+              description: |-
+                Can be configured with an "admin" gateway to restrict access to applications that only need sysadmin access. Not standard in BB itself though.
+                AC-6.3 is not required for FedRAMP Moderate.
+            - uuid: 3772B5F3-34BC-4EAE-B739-8499F828C2F4
+              control-id: ac-6.9
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system audits the execution of privileged functions.
+                # How does Istio help? Istio produces logs for all traffic in the information system – see AU-3 below for more information on what information is logged and how to configure additional information to be logged with each access. As long as the privileged functions are exposed as network endpoints in the information system, Istio will log their use like it logs all other network traffic.
+                Logging privileged use outside of the information system – like using kubectl to access the cluster directly – is outside of the scope of Istio's runtime logging.
+                Note that Istio does not log the specific individual identities that made the request, though it does log other identifying information like IP addresses used for access.
+                # Detailed Instructions See AU-3 for information on configuring Istio's logs to include more (or less) information.
+            - uuid: 6109E09A-8279-44AB-8CA4-2051AF895648
+              control-id: ac-14
+              description: |-
+                Istio implements with mission team configuration
+                # Control Summary The organization:
+                  a. Identifies [Assignment: organization-defined user actions] that can be performed on the information system without identification or authentication consistent with organizational missions/business functions; and
+                  b. Documents and provides supporting rationale in the security plan for the information system, user actions not requiring identification or authentication.
+
+                # How does Istio help? Istio can be configured to extract end-user credentials from requests for authentication (either locally, or forwarding them on to an external authorization service), and to disallow requests without authentication tokens. This is configured using RequestAuthentication and AuthorizationPolicy resources, described at length in AC-4 above.
+                Using this, Istio's authorization policy becomes documentation of services that do not require authentication.
+                # Detailed Instructions See AC-4 and AC-4 (21) above for information on configuring authentication at runtime, as well as access control policies for denying traffic without credentials.
+                # BigBang Implementation BigBang's default configuration of Istio ensures requests have authentication and authorization applied, including end-user credential validation via authservice. For this reason, all methods are protected and require authentication by default. Any methods exempted from the requirement for authentication need to explicitly author an authorization policy opting out of the platform's built-in checks.
+                This configuration is only valid when applications opt in to authservice; the same guarantees cannot be made at the platform level for applications that do not use the platform SSO via authservice.
+            - uuid: 9B6BA674-E6ED-4FB6-B216-3C8733F36411
+              control-id: au-2
+              description:
+                Istio provides access logs for all HTTP network requests, including
+                mission applications.
+            - uuid: D3CBC898-F938-4FAA-B1B1-2597A69B5600
+              control-id: au-3
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system generates audit records containing information that establishes what type of event occurred, when the event occurred, where the event occurred, the source of the event, the outcome of the event, and the identity of any individuals or subjects associated with the event.
+                # How does Istio help? Istio generates access logs for all traffic in the mesh (ingress, internal, and egress) that is a superset of the data in the [Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format). For HTTP traffic, this includes timestamp, source and destination IPs, request verb, response code, and more. You can get a full overview of the data that is provided [in the Istio documentation](https://istio.io/latest/docs/tasks/observability/logs/access-log/). The format of these logs can be configured per deployment or globally at install time to conform with requirements of existing log analysis tools or other organizational needs.
+                By default, Envoy sidecars in the mesh emit these logs as text to standard out. However, Envoy can be configured to forward this log data over gRPC to a server that aggregates (and potentially acts on) them. This is called the [Access Log Service (ALS)](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/accesslog/v3/als.proto).
+                These can be augmented by application-specific audit logging, but for many services (and HTTP services especially), the mesh's logs are sufficient to reconstruct an understanding of events to perform an audit.
+                Istio does not include the identity of the individuals associated with the event by default, though in some cases they may be identifiable by the IP addresses logged by Istio.
+                # Detailed Instructions The access log file, encoding, and format (data logged) can be configured at installation time.
+                ``` apiVersion: install.istio.io/v1alpha1 kind: IstioOperator metadata:
+                  name: controlplane
+                  namespace: istio-system
+                spec:
+                  # profile: default
+                  # ...
+                  meshConfig:
+                    accessLogFile: /dev/stdout
+                    accessLogEncoding: TEXT # or JSON
+                    accessLogFormat: “too long, see the docs”
+                ```
+                [Istio's docs](https://istio.io/latest/docs/tasks/observability/logs/access-log/#default-access-log-format) cover the default access log format string and configuring it in Istio. [Envoy's docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) cover all the data Envoy can emit at runtime and which operators to add to the format string to emit them. The default format string covers most use cases, but can be augmented with additional information (or extra information removed) as needed.
+                # BigBang Implementation BigBang ships with Istio's default logging, which is sufficient to satisfy organizational requirements. Therefore, Istio satisfies AU-3 requirements in BigBang deployments.
+            - uuid: 630301DB-8730-4107-9E14-A1EEDE351122
+              control-id: au-3.1
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system generates audit records containing the following additional information: [Assignment: organization-defined additional, more detailed information].
+                # How does Istio help? Istio’s access logs can be configured to produce additional information as needed by the organization.
+                # Detailed Instructions See AU-3 instructions above for configuring the access log string and links to documentation for all available data that can be emitted.
+            - uuid: 6F2A603C-D240-47F1-9BED-334000E15011
+              control-id: au-9
+              description: |-
+                Istio contributes but does not implement
+                # Control Summary The information system protects audit information and audit tools from unauthorized access, modification, and deletion.
+                # How does Istio Help? If you’re using Istio to produce audit information (see AU-3, AU-3 (1)), then the logs that Istio produces are subject to AU-9 controls. Protecting the logs that Istio produces is outside of the scope of Istio itself, but integrating your log ingestion and protection system with the logs that Istio produces, you can easily satisfy this requirement.
+                # Detailed Instructions See AU-3 for details on how to configure Istio’s logging output. A common pattern we see is using a log collection daemon – like Fluentd – to collect local logs and persist them in a datastore conforming to AU-9. In this case, your log collector’s configuration needs to match Istio’s log output configuration (they need to agree on a log file, standard out, or the collector needs to be configured to collect all output  – standard out as well as any files written).
+                Kubernetes RBAC should be configured to allow only specific users access to the log files Envoy produces, ideally no users should have direct access and instead only access logs via the log ingestion system (like Splunk).
+            - uuid: 6F2A603C-D240-47F1-9BED-334000E15011
+              control-id: au-9.2
+              description: |-
+                Istio contributes but does not implement
+                # Control Summary The information system backs up audit records [Assignment: organization-defined frequency] onto a physically different system or system component than the system or component being audited.
+                # How does Istio Help? See AU-9 above, but in short: ensure that Istio’s logging configuration aligns with your larger log collection pipeline. The log collection pipeline itself should implement the AU-9 controls required by the organization.
+                # Detailed Instructions See AU-9 for information on preserving Istio’s logs conforming to AU-9 controls (including this one). In short, your log storage system itself should implement AU-9 (2) controls by persisting logs it stores on physically separate infrastructure.
+            - uuid: 13EC0F18-2696-4407-8478-3AFE839D4764
+              control-id: AU-12
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system:
+                  a. Provides audit record generation capability for the auditable events defined in AU-2 a. at [Assignment: organization-defined information system components];
+                  b. Allows [Assignment: organization-defined personnel or roles] to select which auditable events are to be audited by specific components of the information system; and
+                  c. Generates audit records for the events defined in AU-2 d. with the content defined in AU-3.
+
+                # How does Istio Help? Istio generates logs for all network traffic - TCP connections, HTTP requests, etc. These events are a subset of all events defined by most organizations in AU-2 a. as worthy of audit. See AU-3 for details of the information that can be generated, and AU-3 (1) for information on customizing it.
+                If the only events to be logged per AU-2 a. are network events, then Istio satisfies AU-12 fully for the information system.
+                # Detailed Instructions See AU-3 for information on logging with Istio. As long as all information required by your organization’s policy for AU-2 a., then Istio satisfies AU-12 for your organization. Otherwise, Istio’s logs can be merged with logs from other data sources which together satisfy the requirements of AU-12 for the organization.
+                # BigBang Implementation BigBang configures Istio to emit logs for all network traffic out of the box. These logs conform to the requirements of UA-3 (see that section for details). These logs cover the events listed in UA-2. Therefore Istio in BigBang satisfies AU-12.
+            - uuid: D01F6B2D-F18E-47E9-94DC-95C0B5675E13
+              control-id: cm-5
+              description: |-
+                Istio contributes but does not implement
+                # Control Summary The organization defines, documents, approves, and enforces physical and logical access restrictions associated with changes to the information system.
+                # How does Istio Help? Istio is configured with Kubernetes Custom Resources. As such it can be configured as code, and managed by your existing CM-5 conformant code management processes. Kubernetes RBAC should be used to control who can change which configuration at runtime.
+                # Detailed Instructions Istio’s custom resources control all of its runtime behavior, including encryption in transit between applications, logical segmentation of applications, and more. As such, managing Istio’s configuration is vital to a safe and secure deployment.
+                Organizations should implement an infrastructure-as-code approach for managing Istio, treating its configuration just like application code changes. Humans should not be allowed to change the running system’s configuration, and code review processes should govern what changes are allowed to the infrastructure configuration codebase. Istio’s configuration should be managed by the same CM-5 conformant practices.
+                # BigBang Implementation BigBang implements CM-5 controls by implementing infrastructure as code practices, configuring Kubernetes RBAC to prevent humans from authoring configuration and allowing only continuous delivery systems (Flux, by default) to author runtime configuration. Since all configuration is managed in this CM-5 conformant way, Istio’s configuration is controlled in a CM-5 conformant way.
+            - uuid: 618C16DE-82D0-46FF-9A3A-D260D5F4F654
+              control-id: cm-6
+              description: |-
+                Istio contributes but does not implement
+                # Control Summary The organization:
+                  a. Establishes and documents configuration settings for information technology products employed within the information system using [Assignment: organization-defined security configuration checklists] that reflect the most restrictive mode consistent with operational requirements;
+                  b. Implements the configuration settings;
+                  c. Identifies, documents, and approves any deviations from established configuration settings for [Assignment: organization-defined information system components] based on [Assignment: organization-defined operational requirements]; and
+                  d. Monitors and controls changes to the configuration settings in accordance with organizational policies and procedures.
+
+                # How does Istio Help? This document provides the guidance for configuring Istio, both globally as well as for mission teams. Additional best practices should be followed, including: - NIST SP 800-204A: Building Secure Microservices-based Applications Using Service-Mesh Architecture - NIST SP 800-204B: Attribute-based Access Control for Microservices-based Applications using a Service Mesh
+                # Detailed Instructions AC-3, AC-4, AU-3, SC-7(5) for specific configuration recommendations and patterns in this document. See the Istio in Production guide for detailed installation and per-Mission-Team settings that should be implemented for a best practice secure deployment, but do not directly contribute to an SP 800-53 control.
+                # BigBang Implementation Tetrate helps maintain and periodically audits BigBang’s Istio configurations to ensure they implement best practice defaults.
+            - uuid: 6370B2DA-1E35-4916-8591-91FB9EDBE72B
+              control-id: cm-8
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The organization:
+                  a. Develops and documents an inventory of information system components that:
+                    1. Accurately reflects the current information system;
+                    2. Includes all components within the authorization boundary of the information system;
+                    3. Is at the level of granularity deemed necessary for tracking and reporting; and
+                    4. Includes [Assignment: organization-defined information deemed necessary to achieve effective information system component accountability]; and
+                  b. Reviews and updates the information system component inventory [Assignment: organization-defined frequency].
+
+                # How does Istio Help? Istio catalogs all services in the cluster, as well as their specific instances. Using tools like Kiali or Tetrate Service Bridge, you can view this inventory at any time.
+                  a. Istio provides an inventory of services in the information system:
+                    1. This inventory is kept up to date by Istio based on the Kubernetes API Server in real time (Istio uses this information for runtime service discovery, in addition to providing this inventory), therefore it reflects the current state of the information system.
+                    2. Because Istio provides authorization (AC-4), all components within the authorization boundary are in Istio’s inventory.
+                    3. Istio inventories to the level of individual instances of each application, the most fine-grained level that can be inventoried.
+                    4. This depends on organizational requirements, but in a typical deployment all information required for accountability is provided by Istio.
+                  b. Istio updates this information continuously based on the Kubernetes API server, satisfying the requirement for regular inventory update.
+
+                # Detailed Instructions Istio provides this inventory of the information system as a byproduct of facilitating service discovery for all applications in the information system. As a result, no special configuration or settings are required. A deployment of a software to visualize the inventory – like Kiali or Tetrate Service Bridge – is useful for getting the full value of Istio’s inventory for operations.
+                # BigBang Implementation BigBang’s Istio deployment satisfies this requirement. Further, BigBang includes Kiali, providing an easy view for this data.
+            - uuid: AB9189FF-34E2-4D7E-8018-EB346C7AE967
+              control-id: cm-8.1
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The organization updates the inventory of information system components as an integral part of component installations, removals, and information system updates.
+                # How does Istio Help? Istio’s service inventory is updated continuously from the Kubernetes API server (the information system’s source of truth for what applications are running). Therefore, the inventory is updated when components of the information system are installed or removed. As a result, Istio implements CM-8 (1) for the information system.
+                # Detailed Instructions Istio updates its inventory continuously, therefore implements CM-8 (1). CM-8 has more details.
+                # BigBang Implementation BigBang’s Istio deployment satisfies this requirement automatically.
+            - uuid: A740C741-23B4-4ED9-937C-E0276A9B92EE
+              control-id: cm-8.2
+              description: |-
+                Provides an inventory of all workloads (including mission apps) in the service mesh, viewable in Kiali. The inventory is automatically and continuously updated.
+                CM-8.2 is not required for FedRAMP Moderate.
+            - uuid: 61615706-5395-4168-8AD0-5C4ACBCC5D7E
+              control-id: ia-2
+              description: |-
+                Istio implements with mission team configuration
+                # Control Summary The information system uniquely identifies and authenticates organizational users (or processes acting on behalf of organizational users).
+                # How does Istio Help? Istio can be used to implement authentication of end-user credentials for applications in the mesh. This is typically configured via Istio’s external authorization service or by validating JWTs on each request (see AC-3).
+                If components in the information system are protected by Istio configured to validate end-user credentials, then Istio satisfies the authentication clause IA-2: “[the information system] authenticates organizational users (or processes acting on behalf or organizational users).” Assigning user identities themselves, and ensuring their uniqueness, is out of scope of Istio. (Istio does assign identities to applications or processes running in the information system – see AC-4.)
+                # Detailed Instructions See AC-3 for configuring the mesh to authenticate end user credentials. See AC-4 for configuring the mesh to authenticate workloads (processes) in the information system.
+                # BigBang Implementation BigBang deploys authservice as part of its default configuration. Istio implements IA-2 for all applications that opt in to using authservice because BigBangs configuration prohibits all traffic that is not authenticated in that case. See AC-14 for more information on authservice in BigBang.
+            - uuid: 3004BB1D-0F50-48F1-ABFE-40CC522B1C15
+              control-id: ia-4
+              description: |-
+                Istio contributes but does not implement
+                # Control Summary The organization manages information system identifiers by:
+                  a. Receiving authorization from [Assignment: organization-defined personnel or roles] to assign an individual, group, role, or device identifier;
+                  b. Selecting an identifier that identifies an individual, group, role, or device;
+                  c. Assigning the identifier to the intended individual, group, role, or device;
+                  d. Preventing reuse of identifiers for [Assignment: organization-defined time period]; and
+                  e. Disabling the identifier after [Assignment: organization-defined time period of inactivity].
+
+                # How does Istio Help? Istio assigned identities to runtime entities based on their Kubernetes service account. Service accounts are unique per (namespace, service account name) pair and are assigned to all pods in the cluster. Pods should opt in to using a specific service account, but if they do not then Kubernetes provides a default service account per namespace.
+                The identities Istio assigned are:
+                  a. Authorized for the specific application by checking against the Kubernetes API server (the system of record for runtime identities).
+                  b. Each service receives an identity from Kubernetes at runtime, whether it is assigned explicitly or not.
+                  c. Sent only to correct workloads because Istio authenticates runtime proofs (mainly, the pod’s service account token) in addition to authorizing the identity by checking with the Kubernetes API server.
+                  d. Service accounts in Kubernetes are unique. However, Kubernetes-level controls (out of the scope of Istio) need to be implemented to ensure that identities are not re-used.
+                  e. The Kubernetes service account lifecycle is out of scope of Istio. A Kubernetes-level control is need to satisfy this requirement.
+
+                So long as Kubernetes service accounts are being managed in accordance with IA-4 – specifically implementing IA-4 d. and IA-4 e., then Istio itself implements IA-4 for application identities used for communication among components of the information system.
+                # Detailed Instructions As long as peer authentication is enabled (see AC-4), Istio satisfies IA-4 a–c. automatically and without configuration. Kubernetes level controls are required for implementing IA-4 d. and e. If Kubernetes satisfies IA-4 controls, then Istio satisfies IA-4 controls for runtime identities of entities within the information system.
+                # BigBang Implementation BigBang implements service account management practices in accordance with IA-4, therefore BigBang’s Istio identities for mission applications satisfy IA-4 requirements.
+            - uuid: 3FC44715-6068-44E5-9079-641D3FAA6A14
+              control-id: ia-7
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system implements mechanisms for authentication to a cryptographic module that meet the requirements of applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance for such authentication.
+                # How does Istio Help? Istio provides encryption in transit for all applications in the mesh, and can also provide TLS termination at ingress and TLS origination at egress. Tetrate Istio Distribution (TID) is the only FIPS 140-2 Verified Istio distribution that exists. It is available from the Iron Bank.
+                When using the TID FIPS builds, all communication between components of the information system is encrypted using FIPS 140-2 verified software.
+                # Detailed Instructions Deploy the FIPS build of the Tetrate Istio Distribution, from Iron Bank or Tetrate directly. This version of Istio is built against BoringSSL ([CMVP Certificate #3678](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678)) and verified by a NIST-accredited third party via runtime and code audit. Tetrate can produce this attestation upon request for TID customers.
+                # BigBang Implementation BigBang uses the FIPS builds from the Tetrate Istio Distribution by default, therefore uses the best available cryptographic libraries by default.
+            - uuid: FE110D6B-CCB5-41E8-B2DE-287ED843D417
+              control-id: ia-9
+              description: |-
+                Istio registers all workload identities in the service mesh. The identity is transmitted in the mTLS certificate when establishing communication between services, and is validated by Istio sidecars.
+                IA-9 is not required for FedRAMP Moderate.
+            - uuid: 82AC8314-BDA8-4A4D-B54D-4A0233563C7C
+              control-id: sc-1
+              description: |-
+                Istio contributes but does not implement
+                # Control Summary The organization:
+                  a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+                    1. A system and communications protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+                    2. Procedures to facilitate the implementation of the system and communications protection policy and associated system and communications protection controls; and
+                  b. Reviews and updates the current:
+                    1. System and communications protection policy [Assignment: organization-defined frequency]; and
+                    2. System and communications protection procedures [Assignment: organization-defined frequency].
+
+                # How does Istio Help? Istio provides a number of controls under the System and Communications Protection category. As such, it should be part of your policy (SC-1 a.1) and managing its configuration should fall under your documentation (SC-1 a.2).
+                # Detailed Instructions This document provides a lot of the data required to incorporate Istio into your system and communications protection policy. CM-6 gives more insight into best-practice Istio configurations as well as other source documents you should consider when building your security policy incorporating Istio
+                # BigBang Implementation BigBang provides extensive documentation for its components [here](TODO). The overall security policy is documented [here](TODO).
+            - uuid: 986E0C8B-6956-42AF-804E-FDB366DE6EDC
+              control-id: sc-7
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system:
+                  a. Monitors and controls communications at the external boundary of the system and at key internal boundaries within the system;
+                  b. Implements subnetworks for publicly accessible system components that are [Selection: physically; logically] separated from internal organizational networks; and
+                  c. Connects to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with an organizational security architecture.
+
+                # How does Istio Help? Istio alone can not completely satisfy the SC-7 requirement, because Istio sits at Layer 4 and above – in other words it sits atop the IP network you provide it. However, Istio can aid in implementing boundary protection in your stack:
+                  a. Istio provides monitoring (AU-12) and control of traffic ingressing into and egressing out of the cluster, as well as internally for all communication between components. If all information system components are running in the cluster, this satisfies SC-7 a.
+                  b. Istio operates at layer 4 and above - it cannot implement subnetworks at the IP layer. However, Istio can be used for logical separation of components at runtime (see AC-4 (21)). Istio’s separation should be augmented with network-level separation, e.g. via a CNI plugin, to help implement a defense in depth strategy.
+                  c. The only ingress into the cluster is via Istio gateways (AC-3), egress is controlled by Istio gateways (AC-4). If all information system components are running in the cluster, this satisfies the needs of SC-7 c. Further, access policy can be applied at both points, as well as at every application instance via Istio’s sidecar. This gives the organization the opportunity to implement more fine-grained controls than is needed by SC-7.
+
+                # Detailed Instructions See the instructions for AC-3, AC-4, and AC-4 (21) for guidance on configuring Istio for boundary protection, as well as for internal protection.
+                It’s important to note that in accordance with a zero trust philosophy, Istio supports the same monitoring and control throughout your infrastructure as at the boundary. While Istio enables controls to be implemented at the boundary, it also allows equivalent controls to be enforced at every application instance in the information system. This helps bind attackers in space by limiting their ability to pivot once inside the protected boundary. In effect, it moves the boundary to each individual application instance. This is one of the biggest benefits of the mesh, and why it is key to achieving a zero trust system at runtime.
+                # BigBang Implementation BigBang deployments conform to AC-3, AC-4, as well as AU-12 out of the box. This satisfies the SC-7 a. as well as SC-7 c. When combined with a standard network topology (like deploying BigBang into EKS on GovCloud), combined with BigBang’s default CNI, you also achieve SC-7 b.
+            - uuid: CB84CC94-BBAA-4177-9836-5AD0DE3A9937
+              control-id: sc-7.4
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The organization:
+                  a. Implements a managed interface for each external telecommunication service;
+                  b. Establishes a traffic flow policy for each managed interface;
+                  c. Protects the confidentiality and integrity of the information being transmitted across each interface;
+                  d. Documents each exception to the traffic flow policy with a supporting mission/business need and duration of that need; and
+                  e. Reviews exceptions to the traffic flow policy [Assignment: organization-defined frequency] and removes exceptions that are no longer supported by an explicit mission/business need.
+
+                # How does Istio Help? Like SC-7, Istio works in tandem with a few other components of the infrastructure to satisfy SC-7 (4). For example, it’s common to use an identity-aware proxy (like Platform One’s CNAP), or even a cloud provider load balancer (like an ELB) as the initial interface for an external service, immediately passing the requests on to Istio’s ingress. For all of the information system components in the cluster:
+                  a. Istio provides an interface – its ingress and egress gateways – for external network traffic. Istio allows configuring how that interface is exposed, including ports and protocols as well as certificates that are served. See AC-4.
+                  b. Istio provides fine-grained layer 7 policy on each request to control how traffic flows through that ingress. It enforces this policy at ingress gateways to control the external traffic ingressing into your information system. Istio also enforces them at egress gateways to control how components of your information system communicate with external systems. See AC-4.
+                  c. Istio’s ingress gateways serve TLS (or mTLS) to external systems, and Istio provides mTLS between applications of the information system in the mesh. See AC-4.
+                  d. Istio must be explicitly configured to allow exceptions, either in AuthorizationPolicy documents controlling runtime access or in resource annotations exempting traffic from Istio’s sidecar. These can be used as supporting documents for SC-7 (4) d., but will need to be augmented with organizational documentation citing specific mission needs and durations.
+                  e. This is an organizational activity out of the scope of Istio.
+
+                # Detailed Instructions See the instructions for AC-3, AC-4, and AC-4 (21) for guidance on configuring Istio for boundary protection, as well as internal protection, for controls SC-7 (4) a-c. Istio’s configuration can aid in documenting traffic flow exceptions, but will need to be augmented to implement SC-7 (4) d.
+                # BigBang Implementation BigBang’s default deployment, including CNAP, satisfies SC-7 (4) a-c out of the box (given you implement access control policy for your mission applications, per the guidance in AC-3 and AC-4).
+            - uuid: CB84CC94-BBAA-4177-9836-5AD0DE3A9937
+              control-id: sc-7.5
+              description: |-
+                Istio implements with mission team configuration
+                # Control Summary The information system at managed interfaces denies network communications traffic by default and allows network communications traffic by exception (i.e., deny all, permit by exception).
+                # How does Istio Help? At ingress and egress gateways, Istio denies all traffic that does not have explicit traffic routing policies in the form of a VirtualService attached to the gateways. Inside of the mesh, and to control egress out to external services, you can author AuthorizationPolicies to limit access. Those policies must be written in the “allow with positive matching” style. Together, Istio implements the SC-7 (5) control on behalf of applications in the mesh.
+                # Detailed Instructions
+                ## Ingress and Egress Gateways Istio has two resources that configure the surface area it exposes to clients ingressing into the mesh (and clients in the mesh egressing out): Gateways and VirtualServices. Gateways define the network interface that Envoy exposes – which ports it opens, what protocols it accepts on those ports, and what names (with certificates) it serves on each port. VirtualServices define traffic policy for each protocol on each port and are explicitly attached to Gateways by name.
+                The following Gateway configures an ingress proxy deployment to accept HTTPS traffic on port 443 for the server “example.com”, serving the provided certs to clients at runtime. Given this configuration, the ingress gateway will deny all traffic that is not HTTPS on port 443 for “example.com”. ``` apiVersion: networking.istio.io/v1beta1 kind: Gateway metadata:
+                  name: example-gateway
+                  namespace: istio-system
+                spec:
+                  selector:
+                    app: istio-ingressgateway
+                  servers:
+                  - hosts:
+                    - example.com
+                    port:
+                      number: 443
+                      name: https-443
+                      protocol: HTTPS
+                    tls:
+                      mode: SIMPLE # enables HTTPS on this port
+                      serverCertificate: /etc/certs/servercert.pem
+                      privateKey: /etc/certs/privatekey.pem
+                ``` Traffic can then be allowed into the information system by writing a VirtualService which routes traffic for “example.com” to specific applications in the system: ``` apiVersion: networking.istio.io/v1beta1 kind: VirtualService metadata:
+                  name: example-com-route
+                  namespace: istio-system
+                spec:
+                  hosts:
+                  - example.com
+                  gateways:
+                  # attach this routing behavior to only the gateway above
+                  - example-gateway.istio-system
+                  http:
+                  - name: "examples-default-route"
+                    route:
+                    - destination:
+                        host: examples.default.svc.cluster.local
+                ``` Egress gateways behave in the same way, and will only route out to external services that are allowed by the VirtualSerice you attach to them.
+                In this way, Istio denies all inbound and outbound traffic by default, allowing only traffic which is explicitly configured by authoring these two resources (a Gateway and a VirtualService) together.
+                ## Authorization Policy in the Mesh Within the mesh, we use AuthorizationPolicy resources to restrict what applications can communicate. All AuthorizationPolicy should be written in the “allow with positive matching” style. In that style, we write policies with the ALLOW action, using only positive matching fields (e.g. paths, principals, values) and never using negative matching fields (e.g. notPaths, notPrincipals, notValues). ``` apiVersion: security.istio.io/v1beta1 kind: AuthorizationPolicy metadata:
+                  name: allow-with-positive-path-matches
+                spec:
+                  action: ALLOW
+                  rules:
+                  - to:
+                    - operation:
+                        paths: ["/public"]
+                ``` ``` apiVersion: security.istio.io/v1beta1 kind: AuthorizationPolicy metadata:
+                  name: allow-with-positive-principal-list
+                spec:
+                  action: ALLOW
+                  rules:
+                  - from:
+                    - principals: ["cluster.local/ns/default/sa/productpage"]
+                ``` Equivalently, we could write with action DENY and use only negative matching fields – called “deny with negative matching”. Within a single organization, we recommend that only one style be allowed to reduce the chance of human error in authoring policies, and recommend “allow with positive matching”.
+                Taken together, Istio implements a default deny with traffic allowed only by explicit configuration, satisfying SC-7 (5) on behalf of applications in the mesh.
+                # BigBang Implementation BigBang’s default configuration enforces deny by default behavior for ingress and egress. Developers building mission applications writing their own access policy (per AC-4) must write policy in the “allow with positive matching” style. If they do so, the entire system conforms to SC-7 (5).
+            - uuid: CB84CC94-BBAA-4177-9836-5AD0DE3A9937
+              control-id: sc-8
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system protects the [Selection (one or more): confidentiality; integrity] of transmitted information.
+                # How does Istio Help? Istio provides encryption in transit (TLS) for all applications in the mesh. This ensures both confidentiality and integrity of communication between applications deployed in the mesh. When you deploy a FIPS verified build of Istio (e.g. from the Tetrate Istio Distribution), that encryption conforms to FIPS 140-2 requirements. When Istio is configured in STRICT mTLS mode (see AC-4), it implements the SC-8 control for all applications in the mesh.
+                # Detailed Instructions Follow the instructions in AC-4 for enforcing strict mTLS. Ensure you’re deploying the Tetrate Istio Distribution’s FIPS build for encryption that conforms to FIPS 140-2 requirements. Certificates attesting to that build’s verification by a NIST-approved third party auditor are available upon request for TID and TSB customers.
+                # BigBang Implementation BigBang deploys the FIPS builds of TID by default, and enforce STRICT mTLS between components through configuration. Therefore, BigBang’s deployment of Istio implements SC-8 on behalf of applications deployed in the platform.
+            - uuid: 69415B92-0490-4A14-9E0F-E1EE61951F9C
+              control-id: sc-8.1
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system implements cryptographic mechanisms to [Selection (one or more): prevent unauthorized disclosure of information; detect changes to information] during transmission unless otherwise protected by [Assignment: organization-defined alternative physical safeguards].
+                # How does Istio Help? See SC-8 for full details. In short, Istio provides encryption in transit (mutual TLS) for all applications in the mesh. When you’re using TID’s FIPS verified build of Istio, then this encryption also satisfies FIPS 140-2 requirements.
+                # Detailed Instructions Follow the instructions in AC-4 for enforcing strict mTLS. Ensure you’re deploying the Tetrate Istio Distribution’s FIPS build for encryption that conforms to FIPS 140-2 requirements. Certificates attesting to that build’s verification by a NIST-approved third party auditor are available upon request for TID and TSB customers.
+                # BigBang Implementation BigBang deploys the FIPS builds of TID by default, and enforce STRICT mTLS between components through configuration. Therefore, BigBang’s deployment of Istio implements SC-8 (1) on behalf of applications deployed in the platform.
+            - uuid: B6B9D143-6936-4C33-BF2A-3C2B1F282B25
+              control-id: sc-13
+              description: |-
+                Istio implements with global configuration
+                # Control Summary The information system implements [Assignment: organization-defined cryptographic uses and type of cryptography required for each use] in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
+                # How does Istio Help? As outlined in the section on SC-8, Istio provides encryption in transit for all applications in the mesh. The Tetrate Istio Distribution’s FIPS Verified build is the only FIPS verified build of Istio and Envoy available, and satisfies requirements for FIPS 140-2 as well as the requirement to use the best available software for the job.
+                # Detailed Instructions Follow the instructions in AC-4 for enforcing strict mTLS at runtime.
+                # BigBang Implementation BigBang deploys the FIPS builds of TID by default, and enforce STRICT mTLS between components through configuration. Therefore, BigBang’s deployment of Istio implements SC-13 on behalf of applications deployed in the platform.
+          uuid: 06717F3D-CE1E-494C-8F36-99D1316E0D13
+      uuid: 81F6EC5D-9B8D-408F-8477-F8A04F493690
+      title: Istio Controlplane
+      description: |
+        Istio Service Mesh
+      type: software
+      purpose: Istio Service Mesh
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - 72134592-08C2-4A77-ABAD-C880F109367A
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/usnistgov/oscal-content/master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json
+          description: Controls implemented by Kyverno for inheritance by applications
+          implemented-requirements:
+            - uuid: 7D019F27-294F-4759-A44F-BA6E15370ED8
+              control-id: cm-4
+              description:
+                The CLI can be used in CI/CD pipelines to assist with the resource
+                authoring process to ensure they conform to standards prior to them being
+                deployed.
+            - uuid: 91302CE7-181E-4464-9E26-2A1E42D8909F
+              control-id: cm-4.1
+              description:
+                Use of auditing validationFailureAction state in a test environment
+                would allow changes to be tested against policies without blocking development.
+                Allowing for policies to be mirrored and enforced in production.
+            - uuid: BE54EDE4-8279-4AE6-B8C3-5B68CC235E5E
+              control-id: cm-6
+              description:
+                Kyverno can be configured for cluster-wide and namespaced policies
+                for system configuration. Exceptions can be implemented to policies that
+                will allow for explicit deviations approved by policies/configurations declared
+                in git.
+            - uuid: 6e1f05fc-3eab-45a2-9b16-d2c5acfed20b
+              control-id: cm-7
+              description:
+                Kyverno can enact policies that prevent the use of specific service
+                types (IE, LoadBalancer or NodePort)
+            - uuid: C14EA5F8-3926-4BB4-BE44-B134513F143D
+              control-id: cm-7.5
+              description:
+                Policies can be written to enact deny-all for workloads unless
+                exceptions are identified
+            - uuid: 69A5689A-DAA5-48F6-9953-AEF482B0FEE0
+              control-id: cm-8.3
+              description:
+                Policies can be written to validate all software workloads can
+                be verified against a signature.
+            - uuid: D0CEE97B-A884-4ECB-B56E-34048148144C
+              control-id: cm-8.3
+              description:
+                Policies can be written to restrict the software that can be
+                installed by cluster users.
+            - uuid: CBCB72ED-3161-4A6F-B522-FB7082E6E380
+              control-id: sr-11
+              description:
+                Cluster-Wide Policies can be written to require all images be
+                verified through signature verification.
+          uuid: 5108E5FC-C45F-477B-A542-9C5611A92485
+      uuid: 33d8fdde-f6ab-462a-8923-e6e4446d7a10
+      title: Kyverno
+      description: |
+        Deployment as Kyverno as an admission controller for a Kubernetes cluster
+      type: software
+      purpose: Admission controller for the Kubernetes API
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - 72134592-08C2-4A77-ABAD-C880F109367A
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description:
+            Controls implemented by GitLab for inheritance by applications
+            that adheres to FedRAMP High Baseline and DoD IL 6.
+          implemented-requirements:
+            - uuid: b080d9c1-717a-4126-ad2a-1a54a466db1b
+              control-id: au-2
+              description:
+                GitLab logs event logs for authentication, account logon, account
+                management events, admin events, data deletions, data changes, and permission
+                changes.
+            - uuid: 1937afb4-ea33-45c0-98f1-56fb5117b328
+              control-id: au-3
+              description:
+                GitLab logs type of event, time of the even, location of the
+                event, source of the event, outcome of the event, and subjects/objects involved
+                in the event.
+            - uuid: 8d0d31b5-88cf-412c-8750-79b6e0177e6d
+              control-id: au-3.1
+              description:
+                GitLab additionally logs the identity, object, or resource that
+                is being acted upon.
+            - uuid: e5d0abe6-42a9-4d8a-9b57-7accc2b96f9c
+              control-id: au-8
+              description: GitLab event logs contain NIST compliant timestamps.
+            - uuid: 028e2d67-0ec5-4867-9848-cf8d4e71352c
+              control-id: au-10
+              description:
+                GitLab event logs contain the unique user or process id that
+                takes the addition, modification, approval, sending, or relieving of data
+                actions.
+            - uuid: 387c6698-8517-4eb4-b085-d3593318f892
+              control-id: au-12
+              description:
+                GitLab logs event logs for authentication, account logon, account
+                management events, admin events, data deletions, data changes, and permission
+                changes.
+            - uuid: 49d01edf-e8f8-4c7b-bcdc-c72e5887c020
+              control-id: cm-3.1
+              description:
+                GitLab provides change control via automated notification, prohibition
+                of changes, testing, validation, documentation of changes, automated change
+                implementation, and security and privacy representatives.
+            - uuid: c9cdede1-d837-4bb9-ba8e-cf81650f6b60
+              control-id: cm-3.2
+              description:
+                GitLab provides change control testing via automated notification,
+                prohibition of changes, testing, validation, documentation of changes, automated
+                change implementation, and security and privacy representatives.
+            - uuid: 51c4cdbe-b8ba-47d1-87b8-1f0703b15606
+              control-id: cm-3.6
+              description:
+                GitLab utilizes the underlying istio for FIPs encryption in transit.
+                GitLab stores data in an encrypted Redis, PostgreSQL, and KMS backed S3
+                Buckets.
+            - uuid: a0e3ea1e-6ccc-4b90-b2f0-87e863804040
+              control-id: cm-8.2
+              description:
+                GitLab maintains the currency, completeness, accuracy, and the
+                inventory of system components within in the system as all parts are stored
+                and deployed through GitLab's CI/CD process.
+            - uuid: ef55c29c-4ad3-4980-a9e0-a041e74c6a4c
+              control-id: sa-3
+              description:
+                GitLab provides management of the system by incorporating information
+                security and privacy considerations within the software development lifecycle
+                through the use of DevSecOps CI/CD pipelines.
+            - uuid: 9b707e59-27ea-4ec6-8690-caafa560847e
+              control-id: sa-4.1
+              description:
+                GitLab provides description of the functional properties, components,
+                and services within the system.
+            - uuid: 5cbc2227-6762-42e9-9719-025987ca97a9
+              control-id: sa-4.2
+              description: GitLab contains the source code for the system and system components.
+            - uuid: 259fa1fc-4c6b-4155-a622-9a24fa3cf821
+              control-id: sa-4.5
+              description:
+                GitLab provides the default configurations for the system, components,
+                or services that are implemented.
+            - uuid: 058dfeba-8842-454e-ad10-529611bc0693
+              control-id: sa-4.9
+              description:
+                GitLab provides the functions, ports, protocols, and services,
+                for the system and system components within the source code.
+            - uuid: 1570a74c-402e-49de-be71-c19a01cb6982
+              control-id: sa-8
+              description:
+                GitLab provides secure CI/CD processes by including unit tests,
+                SAST, building images, SBOMS, scanning images, pushing images to secure
+                repositories, and signing images.
+            - uuid: 3e624332-9163-4d47-905f-6cf0a0ec922b
+              control-id: sa-10
+              description:
+                GitLab documents, manage, and controls the integrity of changes
+                to the system. Provides documentation for approving changes to system and
+                system components within the system.
+            - uuid: bf80d8d9-4318-46c0-9730-091975f792e0
+              control-id: sa-11
+              description:
+                GitLab provides a secure CI/CD process that includes unit tests,
+                SAST scanning, and scanning of images within the pipelines.
+            - uuid: 6049161e-9642-4272-a48e-b2bdcdf46178
+              control-id: sa-11.1
+              description:
+                GitLab utilizes SonarQube and Gitleaks within the secure pipelines
+                to conduct SAST scanning.
+            - uuid: 1bd514fd-545b-4f86-b8d2-9fca5236bef3
+              control-id: sa-11.2
+              description:
+                GitLab utilizes SonarQube and Gitleaks within the secure pipelines
+                to conduct SAST scanning. In addition NueVector is utilized to conduct container
+                image scanning within the pipeline.
+            - uuid: 3d407634-5a25-400b-ac81-be5d27e006f5
+              control-id: sc-13
+              description:
+                GitLab utilized Istio Network for FIPs encryption in transit.
+                FIPs encryption for data at rest is handled by PostgreSQL, Redis, and AWS
+                S3 backed by KMS.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: b11ec73a-bd37-42c8-80ef-c2c3c212d5fa
+      title: GitLab
+      description: |
+        GitLab is a web-based DevOps lifecycle tool that provides a Git-repository manager with wiki, issue-tracking, and CI/CD pipeline features. It enables teams to
+         collaborate on code development, from planning and project management to testing and deployment, all within a single platform.
+      type: software
+      purpose:
+        Provides users with secure DevSecOps pipelines, Git operations, issue-tracking,
+        and CI/CD capabilities.
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description:
+            Controls implemented by GitLab Runners for inheritance by applications
+            that adheres to FedRAMP High Baseline and DoD IL 6.
+          implemented-requirements:
+            - uuid: 6f0a9a9a-c8b1-48bf-bf3a-7dfcbbd7254c
+              control-id: au-3
+              description:
+                GitLab Runners log type of event, time of the even, location
+                of the event, source of the event, outcome of the event, and subjects/objects
+                involved in the event.
+            - uuid: 6addf097-e991-4415-b1bf-6c5208a645d2
+              control-id: au-8
+              description: GitLab Runner event logs contain NIST compliant timestamps.
+            - uuid: bf993771-afb7-4993-a66b-c8e91b281370
+              control-id: cm-3.6
+              description:
+                GitLab Runners utilizes the underlying istio for FIPs encryption
+                in transit. GitLab Runners also utilize the RedHat base container image's
+                FIPs modules. GitLab stores data in an encrypted Redis, PostgreSQL, and
+                KMS backed S3 Buckets.
+            - uuid: ca62ff04-a51a-461d-915a-858082c0b2de
+              control-id: cm-7
+              description:
+                GitLab Runners are configured to only allow specific ports, services,
+                and functionalities required.
+            - uuid: 9cb2a331-a9a0-4497-a047-e50e737c1b10
+              control-id: sa-3
+              description:
+                GitLab Runners help to provide management of the system by incorporating
+                information security and privacy considerations within the software development
+                lifecycle through the use of DevSecOps CI/CD pipelines.
+            - uuid: 034a2d51-c00a-456a-96be-9d8fc83d7906
+              control-id: sa-8
+              description:
+                GitLab Runners help to provide secure CI/CD processes by including
+                unit tests, SAST, building images, SBOMS, scanning images, pushing images
+                to secure repositories, and signing images.
+            - uuid: 46bcbe4e-4ab9-4930-bd16-1c39b51482ce
+              control-id: sa-11
+              description:
+                GitLab Runners help to provide a secure CI/CD process that includes
+                unit tests, SAST scanning, and scanning of images within the pipelines.
+            - uuid: 89ff10c4-344b-48fc-8e6b-ceacafd0664a
+              control-id: sa-11.1
+              description:
+                GitLab Runners help to utilize SonarQube and Gitleaks within
+                the secure pipelines to conduct SAST scanning.
+            - uuid: 0f9a997e-5b23-4d3f-b940-131b091b0102
+              control-id: sa-11.2
+              description:
+                GitLab Runners help tp utilize SonarQube and Gitleaks within
+                the secure pipelines to conduct SAST scanning. In addition NueVector is
+                utilized to conduct container image scanning within the pipeline.
+            - uuid: d26bdc9d-767d-4237-9487-64085d8438eb
+              control-id: sc-13
+              description:
+                GitLab Runners utilize Istio Network for FIPs encryption in transit.
+                FIPs encryption for data at rest is handled by PostgreSQL, Redis, and AWS
+                S3 backed by KMS. GitLab Runners also leverage the RedHat base container
+                image's FIPs modules.
+            - uuid: 15952f05-46ea-4746-b928-7bb8f2beaaaa
+              control-id: sc-45
+              description: GitLab Runners utilize NIST compliant time clock settings.
+            - uuid: 04e10eac-722f-41c8-b23d-3f1b6fb21470
+              control-id: sc-45.1
+              description: GitLab Runners utilize NIST compliant time clock settings.
+            - uuid: e6806de4-c39b-48cc-a706-8bcce4c19e3a
+              control-id: si-10
+              description:
+                GitLab Runners help to provide secure CI/CD processes by including
+                unit tests, SAST, and including input validation to secure repositories.
+            - uuid: 77b76e61-b9d2-46ec-b7d8-040055b0f8c6
+              control-id: si-16
+              description:
+                GitLab Runners help to provide secure CI/CD processes by building
+                from a secure base image with settings configured to help prevent memory
+                leaks.
+            - uuid: 99003bbb-9c55-4f1d-82f5-73b502883f1e
+              control-id: sr-9.1
+              description:
+                GitLab Runners help to provide secure CI/CD processes by including
+                unit tests, SAST, building images, SBOMS, scanning images, pushing images
+                to secure repositories, and signing images.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: c4815d1f-87db-495e-9e70-9e710f17833e
+      title: GitLab
+      description: |
+        GitLab is a web-based DevOps lifecycle tool that provides a Git-repository manager with wiki, issue-tracking, and CI/CD pipeline features. It enables teams to
+         collaborate on code development, from planning and project management to testing and deployment, all within a single platform.
+      type: software
+      purpose:
+        Provides users with secure DevSecOps pipelines, Git operations, issue-tracking,
+        and CI/CD capabilities.
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description:
+            Controls implemented by SonarQube for inheritance by applications
+            that adheres to FedRAMP High Baseline and DoD IL 6.
+          implemented-requirements:
+            - uuid: 55993d5e-a53f-4a85-8e5e-949f0da24b43
+              control-id: au-2
+              description:
+                "SonarQube creates logs as it conducts secure code scanning within
+                the secure DevSecOps pipeline.  "
+            - uuid: 25b50886-be11-46ae-bece-8c832fb85426
+              control-id: au-3
+              description:
+                "SonarQube creates logs as it conducts secure code scanning within
+                the secure DevSecOps pipeline.  "
+            - uuid: 1e89f273-7e85-4e76-8c10-190c3fdfddfc
+              control-id: au-3.1
+              description:
+                "SonarQube creates logs as it conducts secure code scanning within
+                the secure DevSecOps pipeline.  "
+            - uuid: 2afccc07-f998-46f0-a05f-55985c9e58a0
+              control-id: au-8
+              description: SonarQube event logs contain NIST compliant timestamps.
+            - uuid: 92f94bdb-e8da-45a6-9f0e-6cd4dc49eaa6
+              control-id: ca-2.2
+              description:
+                "SonarQube runs automated code scanning to discover vulnerabilities
+                as apart of the secure DevSecOps pipeline as code it committed. "
+            - uuid: c092d3d3-66ca-4922-ac76-d38440640648
+              control-id: ca-7
+              description:
+                "SonarQube assists with the ConMon process be conducting automated
+                security code scanning in the secure DevSecOps pipelines to discover code
+                vulnerabilities as code is committed.  "
+            - uuid: e4037835-5d80-4f09-9303-42045e5a588f
+              control-id: cm-3.6
+              description:
+                SonarQube utilizes the underlying istio for FIPs encryption in
+                transit. SonarQube stores data in an encrypted PostgreSQL database.
+            - uuid: 77cf50ed-8c24-4343-87cf-081311496470
+              control-id: cm-6
+              description:
+                SonarQube helps to track, monitor, and find any deviations of
+                configuration settings through secure code scanning in DevSecOps pipelines.
+            - uuid: fe87410c-4d1d-42b9-af7a-966aea80972b
+              control-id: ra-5
+              description:
+                SonarQube assists with monitoring and scanning for vulnerabilities
+                through secure code scanning in the DevSecOps pipelines as code is committed.
+            - uuid: 6e75a7cf-2e02-4f6f-9854-0b099ee91ba9
+              control-id: ra-5.2
+              description:
+                SonarQube updates the vulnerability database through upgrading
+                the version and or plugin updates.
+            - uuid: 3f7ac75e-dba9-43b0-b4c6-706c1edbb74e
+              control-id: ra-5.3
+              description:
+                SonarQube conducts secure code scanning against all code committed
+                in the DevSecOps pipelines to identify vulnerabilities.
+            - uuid: fcb8b679-e132-4160-8e45-886b79e82bd7
+              control-id: ra-5.5
+              description:
+                SonarQube has access to scan all of the code committed in the
+                secure DevSecOps pipeline.
+            - uuid: 5dae7f2c-b196-4051-a187-ae71ec26c6b5
+              control-id: sa-11
+              description:
+                SonarQube helps to provide a secure CI/CD process that includes
+                secure code scanning within the pipelines.
+            - uuid: ce66eaa4-af43-47b7-8835-2a52d0da046a
+              control-id: sa-11.1
+              description:
+                SonarQube conducts SAST scanning within the secure DevSecOps
+                pipelines.
+            - uuid: 7016355d-8d8e-4938-9407-3947fcd75b77
+              control-id: sa-11.2
+              description:
+                SonarQube conducts SAST scanning within the secure DevSecOps
+                pipelines each time code is committed.
+            - uuid: 2633134e-b344-4866-98d2-857b5c348a79
+              control-id: si-2.3
+              description:
+                SonarQube assists in identifying flaws through secure code scanning
+                within the secure DevSecOps pipelines as code is committed.
+            - uuid: 4839f599-54f1-4fed-acaf-a8cd5673ebb1
+              control-id: si-6
+              description:
+                SonarQube helps to verify the correct operation of code bases
+                through secure code scanning within the DevSecOps pipelines.
+            - uuid: 4c3d26d2-b9b7-4123-a836-ef126be56bd6
+              control-id: si-11
+              description:
+                SonarQube will identify error handling configurations as a part
+                of the secure code scanning conducted within the DevSecOps pipelines.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: 4b0f8305-6a62-4597-b935-d3d2140a3330
+      title: SonarQube
+      description: |
+        SonarQube is security tool designed for continuous inspection of code quality. It performs automatic reviews with static analysis of code to detect bugs, code smells, and security vulnerabilities for several programming languages.
+      type: software
+      purpose:
+        Provides users with secure code analysis through DevSecOps pipelines,
+        Git operations, and CI/CD capabilities.
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description:
+            Controls partially implemented by Jira for inheritance by applications
+            that adheres to FedRAMP High Baseline and DoD IL 6.
+          implemented-requirements:
+            - uuid: f64a213c-0cb6-4433-b61e-e966c457837f
+              control-id: au-2
+              description: "Jira creates event logs.  "
+            - uuid: e0e8da6e-efdb-4fbe-8b54-7ef5704332ec
+              control-id: au-3
+              description: "Jira creates event logs.  "
+            - uuid: 5810008a-8754-4fab-87ac-a42c689e85fd
+              control-id: au-3.1
+              description: "Jira creates event logs.  "
+            - uuid: 4966cf6e-d042-4e6c-b481-2582e859e265
+              control-id: au-8
+              description: Jira event logs contain NIST compliant timestamps.
+            - uuid: 5049a88c-e8b9-41de-9416-a3511d853992
+              control-id: cp-2
+              description:
+                "Jira partially addreses this control by aiding in the coordination
+                of the contingency plan, tracking updates, and execution. Also aides in
+                incorporating lessons learned through project management.  "
+            - uuid: 47f77cba-6619-446d-bb42-1acaeff49913
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cp-2.1
+              description:
+                Jira partially meets this control by providing a platform for
+                coordination of the contingency plan development.
+            - uuid: cfe111ec-50bb-4422-9310-1e79568899db
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cp-4.1
+              description:
+                Jira partially meets this control by providing a platform for
+                coordination of the contingency plan development.
+            - uuid: bccfac9c-2afe-4252-afb7-4819936b3bbe
+              control-id: cm-3.6
+              description:
+                Jira utilizes the underlying istio for FIPs encryption in transit.
+                Jira stores data in an encrypted PostgreSQL database.
+            - uuid: 7bf3f55a-5b2c-45f3-ba5e-240c5d4850c6
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ir-3
+              description:
+                Jira partially meets this control by providing a platform for
+                coordination of the incident response process.
+            - uuid: a81493bf-22da-45ea-bf79-e57bf1aeb2ce
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ir-3.2
+              description:
+                Jira partially meets this control by providing a platform for
+                coordination of the incident response process.
+            - uuid: a662f681-5772-44b3-8e64-b77b4e3406a4
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ir-5
+              description:
+                Jira partially meets this control by providing a platform for
+                tracking incidents.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: 7dbe25d3-f166-4ce1-8dcb-c2f341812ffe
+      title: Jira
+      description: |
+        Jira is a project management tool developed by Atlassian, primarily used for issue tracking and agile project management. It enables teams to plan, track, and manage software development projects with various customizable workflows and reporting features.
+      type: software
+      purpose: Provides users with secure project management and issue tracking capabilities.
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description:
+            Controls partially implemented by Confluence for inheritance by
+            applications that adheres to FedRAMP High Baseline and DoD IL 6.
+          implemented-requirements:
+            - uuid: e0b69b26-83b1-4a15-9910-b6db413e50e563db05
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ac-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 2f3ef038-50a3-4d07-9bd7-d7fda6fe43c4
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: au-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 767b09c3-ab7f-4992-a2a2-100dd863db05
+              control-id: au-2
+              description: "Confluence creates event logs.  "
+            - uuid: 7155ad9a-1a0e-4a37-a75e-45eedb6f8208
+              control-id: au-3
+              description: "Confluence creates event logs.  "
+            - uuid: 25fdbc15-6adf-4c22-941d-791a88489561
+              control-id: au-3.1
+              description: "Confluence creates event logs.  "
+            - uuid: c08883b4-57da-4e2c-8359-600e7fcd0ec2
+              control-id: au-8
+              description: Confluence event logs contain NIST compliant timestamps.
+            - uuid: 73e8fb77-a856-4877-886e-ddd1ec1dbb56
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: at-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: c69afe49-3443-4269-b282-50e94ea12999
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: at-4
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 0858c41b-1fb6-4797-8722-a91c9d4a6c81
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ca-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 434ab6d5-dd0e-44f0-9e75-2d3eb9c6096b
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ca-3
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: b9b390bd-740e-4dfe-94bd-ed7574d178e4
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cm-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 00163748-590f-421a-94b0-5d768aae7894
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cm-9
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 3a4ab35c-f9ed-4291-82a4-2acfd5f765eb
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cm-12
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 3de1025c-dd61-498e-ad34-c488b952986e
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cp-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 4361415b-1868-41e4-b2ef-bd586e22797f
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cp-2
+              description:
+                Confluence partially addreses this control by aiding in the coordination
+                of the contingency plan, tracking updates, and execution. Also aides in
+                incorporating lessons learned through project management.
+            - uuid: cb6af609-2707-4bf6-9874-a67d82a74cd2
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cp-2.1
+              description:
+                Confluence partially meets this control by providing a platform
+                for coordination of the contingency plan development.
+            - uuid: 0248d6a8-dead-42e0-b388-80aeaaa8fee1
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cp-4.1
+              description:
+                Confluence partially meets this control by providing a platform
+                for coordination of the contingency plan development.
+            - uuid: 5c1762a8-b7bc-4e67-9df3-6708c77107a4
+              control-id: cm-3.6
+              description:
+                Confluence utilizes the underlying istio for FIPs encryption
+                in transit. Confluence stores data in an encrypted PostgreSQL database.
+            - uuid: c480bef1-4d53-4d27-831b-84cff57388b2
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ia-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 562b2362-0bdc-4d42-b349-6cdd0d110e68
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ir-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 9b554527-ba8a-4a8d-9e2c-b54270bca393
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ir-3
+              description:
+                Confluence partially meets this control by providing a platform
+                for coordination of the incident response process.
+            - uuid: cd73e290-8472-4205-aaa1-0d304e9e7857
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ir-5
+              description:
+                Confluence partially meets this control by providing a platform
+                for tracking and documenting incidents.
+            - uuid: 4fb2701d-6148-4485-9a4e-aec14878819e
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ir-8
+              description:
+                Confluence partially meets this control by providing a platform
+                for tracking and documenting incidents.
+            - uuid: 76448a96-fdf4-4f01-b00f-01be579b40b2
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ma-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 23ca0c11-df99-4350-b930-41c00915ecd4
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ma-2
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 85805644-68d5-42ba-b2f4-8e218472b7ae
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ma-2.2
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: f125d514-fa98-4e4a-863e-3588195188f2
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: mp-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: ce3133d6-38e2-447e-a6ee-371b4aa3ccc0
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: mp-6.1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: e1da1627-6e28-404e-98ae-afe5ccb8ee5f
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: pe-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 8a49778d-828b-4597-b806-abcb91fcfe72
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: pl-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 4a8cff31-7218-4ceb-9ac4-a43619676bde
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: pl-4
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 57116dab-6ccb-4978-8d9c-33aa67d1add4
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ps-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 9674a6f9-5038-485b-8b8b-b350d0a2893a
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ps-6
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 4d7e8043-e9f2-4bb9-a057-7daaf7cb784a
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ra-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 0fed390e-74e5-4621-a41c-f0a06fdad7d8
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: sa-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 33362397-1b6e-427f-9dc6-6a2fc8fb768c
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: sc-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: c70b1242-d834-428a-806f-bb9ad90598d7
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: si-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+            - uuid: 40dd969e-66bc-41a2-a5bc-bd7b767061fb
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: sr-1
+              description:
+                Confluence partially satisfies this control by providing a secure
+                documentation storage, versioning control, and team collaboration platform.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: 9e5c9099-9a4c-450f-bd4d-08d2ba2d0968
+      title: Confluence
+      description:
+        "Confluence is a collaboration tool that organizes and manages work
+        efficiently by enabling teams to create, share, and collaborate on projects
+        in a centralized space. It integrates seamlessly with other \ntools and provides
+        a platform for documenting, discussing, and tracking progress, making it ideal
+        for project management and team communication.\n"
+      type: software
+      purpose:
+        Provides users with secure project management, documentation, and issue
+        tracking capabilities.
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description:
+            Controls partially implemented by Mattermost for inheritance by
+            applications that adheres to FedRAMP High Baseline and DoD IL 6.
+          implemented-requirements:
+            - uuid: 889dce9c-d83f-48a3-a62a-3f50e311761a
+              control-id: au-2
+              description: "Mattermost creates event logs.  "
+            - uuid: ce2c791e-f47e-45d3-9bba-dcd7a372ddd3
+              control-id: au-3
+              description: "Mattermost creates event logs.  "
+            - uuid: 2ef78f64-d9ac-4292-a5f1-6c627734d39c
+              control-id: au-3.1
+              description: "Mattermost creates event logs.  "
+            - uuid: 1041d516-56b9-4652-886e-bd5bad38f789
+              control-id: au-8
+              description: Mattermost event logs contain NIST compliant timestamps.
+            - uuid: 05c85212-6f2a-480d-b812-b3e2c5bba3e7
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: cp-2
+              description:
+                Mattermost partially addresses this control by aiding in the
+                communication of the contingency plan, updates, and execution.
+            - uuid: 1f53aad7-b772-476c-bf9c-6406daef7cb1
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: ir-8
+              description:
+                Mattermost partially meets this control by providing a secure
+                communication platform for coordination of the incident response plan.
+            - uuid: 4d4a3721-ea7b-4f20-8059-aee0f6a4b432
+              props:
+                - ns: https://lula.dev/ns/oscal
+                  value: partially
+                  name: implemented
+              control-id: pl-2
+              description:
+                Mattermost partially meets this control by providing a secure
+                communication platform for coordination of the system security and privacy
+                plans.
+            - uuid: dab3bce5-b7e9-4387-9fce-73fe2731721a
+              control-id: cm-3.6
+              description:
+                Mattermost utilizes the underlying istio for FIPs encryption
+                in transit. Mattermost stores data in an encrypted PostgreSQL database.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: 9f1c741f-caf0-4d67-8ffe-b0f180132f46
+      title: Mattermost
+      description: |
+        Mattermost is an open-source, self-hostable online chat service designed for team communication and collaboration.
+      type: software
+      purpose: Provides users with secure team communication and collaboration capabilities.
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+    - control-implementations:
+        - source: https://raw.githubusercontent.com/GSA/fedramp-automation/93ca0e20ff5e54fc04140613476fba80f08e3c7d/dist/content/rev5/baselines/json/FedRAMP_rev5_HIGH-baseline-resolved-profile_catalog.json
+          description:
+            Controls implemented by Nexus for inheritance by applications that
+            adheres to FedRAMP High Baseline and DoD IL 6.
+          implemented-requirements:
+            - uuid: a966a557-6d76-4274-9666-b1a7d2fd8b07
+              control-id: au-2
+              description:
+                Nexus logs event logs for authentication, account logon, account
+                management events, admin events, data deletions, data changes, and permission
+                changes.
+            - uuid: c5d66b4a-5336-45b0-afb3-80f76fa189ea
+              control-id: au-3
+              description:
+                Nexus logs type of event, time of the even, location of the event,
+                source of the event, outcome of the event, and subjects/objects involved
+                in the event.
+            - uuid: 46ed69cf-52c5-4fc0-a609-c5500d98b8a0
+              control-id: au-3.1
+              description:
+                Nexus additionally logs the identity, object, or resource that
+                is being acted upon.
+            - uuid: bea2d1dd-89d3-42b3-8414-9eab8dbe3c7e
+              control-id: au-8
+              description: Nexus event logs contain NIST compliant timestamps.
+            - uuid: bddf0206-1401-4b50-bf2a-bf81012a78b9
+              control-id: au-10
+              description:
+                Nexus event logs contain the unique user or process id that takes
+                the addition, modification, approval, sending, or relieving of data actions.
+            - uuid: 0371be31-08ca-4d89-a6df-3d6af06f05b3
+              control-id: au-12
+              description:
+                Nexus logs event logs for authentication, account logon, account
+                management events, admin events, data deletions, data changes, and permission
+                changes.
+            - uuid: 5d6cd34a-40e9-4a75-968d-af933b76160a
+              control-id: cm-3.1
+              description:
+                Nexus provides change control via automated notification, prohibition
+                of changes, validation, documentation of changes, automated change implementation,
+                and security and privacy representatives through versioning of components
+                and artifacts.
+            - uuid: 4b90d68f-c4c8-4a6f-8e41-f6df8df7dbf3
+              control-id: cm-3.2
+              description:
+                Nexus provides change control testing via automated notification,
+                prohibition of changes, testing, validation, documentation of changes, automated
+                change implementation, and security and privacy representatives through
+                versioning of components and artifacts.
+            - uuid: c1fcab43-a011-4d6c-ba40-d65e4c684f0f
+              control-id: cm-3.6
+              description:
+                Nexus utilizes the underlying istio for FIPs encryption in transit.
+                Nexus stores data in an encrypted Redis, PostgreSQL, and KMS backed S3 Buckets.
+            - uuid: 1c4af88f-12b8-407a-a1a9-7dfd8fa37336
+              control-id: cm-8.2
+              description:
+                Nexus maintains the currency, completeness, accuracy, and the
+                inventory of system components within in the system as all parts are stored
+                and deployed through Nexus's CI/CD process.
+            - uuid: 033d181c-31cb-477f-93f5-51ec90f28625
+              control-id: sa-4.1
+              description:
+                Nexus provides description of the functional properties, components,
+                and services within the system.
+            - uuid: 9f7d164e-be45-4ba7-b1c3-e2c5339d65ee
+              control-id: sa-4.2
+              description: Nexus contains the source code for the system and system components.
+            - uuid: 6321cf2f-2a6f-4647-bb1e-8a234f8d8730
+              control-id: sa-4.5
+              description:
+                Nexus provides the default configurations for the system, components,
+                or services that are implemented.
+            - uuid: 0dfb95e2-6dbd-41af-ae45-03671df9e418
+              control-id: sa-4.9
+              description:
+                Nexus provides the functions, ports, protocols, and services,
+                for the system and system components within the source code.
+            - uuid: 332491cd-8096-4e0a-9d24-a79fb5172800
+              control-id: sc-13
+              description:
+                Nexus utilized Istio Network for FIPs encryption in transit.
+                FIPs encryption for data at rest is handled by PostgreSQL, Redis, and AWS
+                S3 backed by KMS.
+          uuid: d2afb4c4-2cd8-5305-a6cc-d1bc7b388d0c
+      uuid: 5e295b82-3abd-4a65-99b7-17f8814e133c
+      title: Nexus
+      description:
+        "Nexus Repository is a powerful and versatile repository manager
+        that supports a variety of package formats and enables the procurement, organization,
+        and distribution of software components. It is widely used \nin software development
+        for efficiently managing both public and private dependencies, and for facilitating
+        the storage, exchange, and management of software artifacts at scale.\n"
+      type: software
+      purpose:
+        Provides users with secure DevSecOps pipelines, storage of software components,
+        storage of software artifacts, and CI/CD capabilities.
+      responsible-roles:
+        - role-id: provider
+          party-uuids:
+            - f3cf70f8-ba44-4e55-9ea3-389ef24847d3
+  back-matter:
+    resources:
+      - uuid: BFF74303-1E06-469E-ADCF-338E6DDB8876
+        title: Github Repo - Kiali
+        rlinks:
+          - href: https://github.com/kiali/kiali
+      - uuid: FF8AA056-BD14-4862-9614-04A2A8C4A26F
+        title: Big Bang Kiali package
+        rlinks:
+          - href: https://repo1.dso.mil/platform-one/big-bang/apps/core/kiali
+      - uuid: 0DA4FE66-9000-49DF-B896-938C94AAE89C
+        title: Tempo
+        rlinks:
+          - href: https://grafana.com/oss/tempo/
+      - uuid: 745E3948-04EE-40E4-9D6A-4F663342A031
+        title: Big Bang Tempo package
+        rlinks:
+          - href: https://repo1.dso.mil/platform-one/big-bang/apps/sandbox/tempo
+      - uuid: 97FF87A0-EB34-4001-839A-32FF0815D896
+        title: Github Repo - Kube Prometheus Stack
+        rlinks:
+          - href: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
+      - uuid: B66A99BD-680E-48AF-B81B-D2113155331E
+        title: Big Bang Monitoring package
+        rlinks:
+          - href: https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring
+      - uuid: b21ef636-e3e7-4386-8f10-b1f3243cc9a6
+        title: NeuVector
+        rlinks:
+          - href: https://open-docs.neuvector.com/
+      - uuid: b4988bfa-d4a7-4095-8523-2e298cc45473
+        title: Big Bang NeuVector package
+        rlinks:
+          - href: https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/neuvector
+      - uuid: D552C935-E40C-4A03-B5CC-4605EBD95B6D
+        title: Promtail
+        rlinks:
+          - href: https://grafana.com/docs/loki/latest/clients/promtail/
+      - uuid: 211C474B-E11A-4DD2-8075-50CDAC507CDC
+        title: Big Bang Promtail package
+        rlinks:
+          - href: https://repo1.dso.mil/platform-one/big-bang/apps/sandbox/promtail
+      - uuid: 95F7C84A-2FD9-4E1C-BB29-7B788ADB716D
+        title: Loki
+        rlinks:
+          - href: https://github.com/grafana/loki
+      - uuid: 1D5F676C-4C34-49DD-8573-2DFC9C948D3A
+        title: Big Bang Loki package
+        rlinks:
+          - href: https://repo1.dso.mil/platform-one/big-bang/apps/sandbox/loki
+      - uuid: 60826461-D279-468C-9E4B-614FAC44A306
+        title: Istio Operator
+        rlinks:
+          - href: https://github.com/istio/istio/
+      - uuid: 41CD9F61-43AB-4220-966A-60F942577C94
+        title: Big Bang Istio Operator package
+        rlinks:
+          - href: https://repo1.dso.mil/platform-one/big-bang/apps/core/istio-controlplane
+      - uuid: 0711df1f-d740-4e39-a25f-15cc7a017f57
+        title: Kyverno
+        rlinks:
+          - href: https://github.com/kyverno/kyverno
+      - uuid: 611ba6d8-8023-4858-b74f-957b15461ac5
+        title: Big Bang Kyverno package
+        rlinks:
+          - href: https://repo1.dso.mil/platform-one/big-bang/apps/sandbox/kyverno
+      - uuid: 0afec63f-4a7e-4a92-b285-c87d3ef50c46
+        title: UDS Capability GitLab
+        rlinks:
+          - href: https://github.com/defenseunicorns/uds-capability-gitlab
+      - uuid: c9602a37-a957-4465-b5df-569a43fc28ce
+        title: UDS Capability GitLab Runner
+        rlinks:
+          - href: https://github.com/defenseunicorns/uds-capability-gitlab-runner
+      - uuid: 2501ae6d-73e5-40e2-a87c-40e88c0c8b62
+        title: UDS Capability SonarQube
+        rlinks:
+          - href: https://github.com/defenseunicorns/uds-capability-sonarqube
+      - uuid: 1f88a599-61ea-4667-a453-8374d03cdeb0
+        title: UDS Capability Jira
+        rlinks:
+          - href: https://github.com/defenseunicorns/uds-capability-jira
+      - uuid: 55a5f362-8002-4461-8e50-40ac01b2944a
+        title: UDS Capability Confluence
+        rlinks:
+          - href: https://github.com/defenseunicorns/uds-capability-Confluence
+      - uuid: 1f88a599-61ea-4667-a453-8374d03cdeb0
+        title: UDS Capability Mattermost
+        rlinks:
+          - href: https://github.com/defenseunicorns/uds-capability-mattermost-operator
+      - uuid: 701a6239-1ec0-4fd1-bd62-7d1dde7e8078
+        title: UDS Capability Nexus
+        rlinks:
+          - href: https://github.com/defenseunicorns/uds-capability-Nexus

--- a/packages/additional-kyverno-exceptions/jira/non-root-user.yaml
+++ b/packages/additional-kyverno-exceptions/jira/non-root-user.yaml
@@ -1,0 +1,22 @@
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: jira-non-root-exceptions
+  namespace: jira
+spec:
+  exceptions:
+  - policyName: require-non-root-user
+    ruleNames:
+    - non-root-user
+  - policyName: restrict-host-path-write
+    ruleNames:
+    - require-readonly-hostpath
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        namespaces:
+        - jira
+        names:
+        - jira-0

--- a/packages/additional-kyverno-exceptions/sonarqube/non-root-user.yaml
+++ b/packages/additional-kyverno-exceptions/sonarqube/non-root-user.yaml
@@ -1,0 +1,22 @@
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: sonarqube-idam-exceptions
+  namespace: keycloak
+spec:
+  exceptions:
+  - policyName: require-non-root-user
+    ruleNames:
+    - non-root-user
+  - policyName: restrict-host-path-write
+    ruleNames:
+    - require-readonly-hostpath
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        namespaces:
+        - keycloak
+        names:
+        - saml-cert

--- a/packages/additional-kyverno-exceptions/zarf.yaml
+++ b/packages/additional-kyverno-exceptions/zarf.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/main/zarf.schema.json
+kind: ZarfPackageConfig
+metadata:
+  name: additional-kyverno-exceptions
+  version: "0.0.1"
+  architecture: amd64
+
+components:
+  - name: sonarqube-idam-kyverno-policy-exception
+    required: true
+    manifests:
+      - name: sonarqube-idam-kyverno-policy-exception
+        namespace: keycloak
+        files:
+          - sonarqube/non-root-user.yaml
+  - name: jira-kyverno-policy-exception
+    required: true
+    manifests:
+      - name: jira-kyverno-policy-exception
+        namespace: jira
+        files:
+          - jira/non-root-user.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -74,7 +74,7 @@
       "datasourceTemplate": "github-tags"
     },
     {
-      "fileMatch": [".*\/?zarf\\.ya?ml$"],
+      "fileMatch": [".*/?zarf\\.ya?ml$"],
       "matchStrings": [
         "-\\s+['\"](?<depName>[^:]+):(?<currentValue>.*)['\"]",
         "\\s*url:\\s+oci://(?<depName>[^:]+):(?<currentValue>.*)"
@@ -90,7 +90,28 @@
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
       "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+    },
+{
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "\\.github/workflows/oscal/config-swf-oscal-component\\.yaml"
+      ],
+      "matchStrings": [
+        "defenseunicorns/uds-capability-gitlab-runner@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "defenseunicorns/uds-package-dubbd@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "defenseunicorns/uds-capability-gitlab-@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "defenseunicorns/uds-capability-sonarqube@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "defenseunicorns/uds-capability-jira@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "defenseunicorns/uds-capability-confluence@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "defenseunicorns/uds-capability-mattermost-operator@(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
+        "defenseunicorns/uds-capability-nexus@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
     }
+  ]
+}
   ],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -74,7 +74,7 @@
       "datasourceTemplate": "github-tags"
     },
     {
-      "fileMatch": [".*/?zarf\\.ya?ml$"],
+      "fileMatch": [".*\/?zarf\\.ya?ml$"],
       "matchStrings": [
         "-\\s+['\"](?<depName>[^:]+):(?<currentValue>.*)['\"]",
         "\\s*url:\\s+oci://(?<depName>[^:]+):(?<currentValue>.*)"

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -6,18 +6,23 @@ metadata:
   version: 0.0.9
   architecture: amd64
 
-zarf-packages:
+packages:
   # Zarf init
   - name: init
     repository: ghcr.io/defenseunicorns/packages/init
-    ref: v0.31.3
+    ref: v0.31.4
     optional-components:
       - git-server
 
   # Defense Unicorns Big Bang Distro
   - name: dubbd-k3d
     repository: ghcr.io/defenseunicorns/packages/dubbd-k3d
-    ref: 0.14.0
+    ref: 0.15.0
+
+  # Additional Kyverno Exceptions
+  - name: additional-kyverno-exceptions
+    path: build
+    ref: 0.0.1
 
   # Namespace pre-reqs for swf capabilities
   - name: software-factory-namespaces
@@ -42,7 +47,7 @@ zarf-packages:
 
   - name: uds-idam
     repository: ghcr.io/defenseunicorns/uds-capability/uds-idam
-    ref: 0.1.14
+    ref: 0.1.15
     imports:
       - name: REALM_IMPORT_FILE
         package: software-factory-idam-realm
@@ -74,19 +79,19 @@ zarf-packages:
   # Gitlab
   - name: gitlab-redis
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-redis
-    ref: 0.1.8
+    ref: 0.1.10
 
   - name: gitlab-minio
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-minio
-    ref: 0.1.8
+    ref: 0.1.10
 
   - name: gitlab-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-postgres
-    ref: 0.1.8
+    ref: 0.1.10
 
   - name: gitlab
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab
-    ref: 0.1.8
+    ref: 0.1.10
     imports:
       - name: GITLAB_IDAM_ENABLED
         package: software-factory-idam-gitlab
@@ -98,11 +103,11 @@ zarf-packages:
   # Gitlab Runner
   - name: gitlab-runner-rbac
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab-runner/dev-dependency/gitlab-runner-rbac
-    ref: 0.1.2
+    ref: 0.1.3
 
   - name: gitlab-runner
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab-runner
-    ref: 0.1.2
+    ref: 0.1.3
 
   # Sonarqube
   - name: sonarqube-postgres
@@ -149,24 +154,24 @@ zarf-packages:
    # Mattermost Operator with a Mattermost instance
   - name: mattermost-minio
     repository: ghcr.io/defenseunicorns/uds-capability/mattermost/dev-dependency/mattermost-minio
-    ref: 0.1.2
+    ref: 0.1.6
 
   - name: mattermost-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/mattermost/dev-dependency/mattermost-postgres
-    ref: 0.1.2
+    ref: 0.1.6
 
   - name: mattermost
     repository: ghcr.io/defenseunicorns/uds-capability/mattermost
-    ref: 0.1.2
+    ref: 0.1.6
 
   # Nexus
   - name: nexus-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/nexus/dev-dependency/nexus-postgres
-    ref: 0.1.2
+    ref: 0.1.3
 
   - name: nexus
     repository: ghcr.io/defenseunicorns/uds-capability/nexus
-    ref: 0.1.2
+    ref: 0.1.3
 
   # Add all virtualservices as internal dns entries for auth callbacks
   - name: software-factory-idam-dns

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -3,7 +3,7 @@ kind: UDSBundle
 metadata:
   name: software-factory-demo
   description: A UDS bundle for deploying a software factory to k3d for demonstration purposes NOT FOR PRODUCTION
-  version: 0.0.11
+  version: 0.0.12
   architecture: amd64
 
 packages:
@@ -19,15 +19,15 @@ packages:
     repository: ghcr.io/defenseunicorns/packages/dubbd-k3d
     ref: 0.15.0
 
-  # Additional Kyverno Exceptions
-  - name: additional-kyverno-exceptions
-    path: build
-    ref: 0.0.1
-
   # Namespace pre-reqs for swf capabilities
   - name: software-factory-namespaces
     path: build
     ref: 1.0.0
+
+  # Additional Kyverno Exceptions
+  - name: additional-kyverno-exceptions
+    path: build
+    ref: 0.0.1
 
   # Change the realm file keycloak imports from
   - name: software-factory-idam-realm
@@ -79,7 +79,7 @@ packages:
   # Gitlab
   - name: gitlab-redis
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-redis
-    ref: 0.1.11
+    ref: 0.1.14
 
   - name: gitlab-minio
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-minio
@@ -91,7 +91,7 @@ packages:
 
   - name: gitlab
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab
-    ref: 0.1.11
+    ref: 0.1.14
     imports:
       - name: GITLAB_IDAM_ENABLED
         package: software-factory-idam-gitlab
@@ -154,24 +154,24 @@ packages:
    # Mattermost Operator with a Mattermost instance
   - name: mattermost-minio
     repository: ghcr.io/defenseunicorns/uds-capability/mattermost/dev-dependency/mattermost-minio
-    ref: 0.1.6
+    ref: 0.1.7
 
   - name: mattermost-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/mattermost/dev-dependency/mattermost-postgres
-    ref: 0.1.6
+    ref: 0.1.7
 
   - name: mattermost
     repository: ghcr.io/defenseunicorns/uds-capability/mattermost
-    ref: 0.1.6
+    ref: 0.1.7
 
   # Nexus
   - name: nexus-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/nexus/dev-dependency/nexus-postgres
-    ref: 0.1.3
+    ref: 0.1.5
 
   - name: nexus
     repository: ghcr.io/defenseunicorns/uds-capability/nexus
-    ref: 0.1.3
+    ref: 0.1.5
 
   # Add all virtualservices as internal dns entries for auth callbacks
   - name: software-factory-idam-dns

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -79,19 +79,19 @@ packages:
   # Gitlab
   - name: gitlab-redis
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-redis
-    ref: 0.1.10
+    ref: 0.1.11
 
   - name: gitlab-minio
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-minio
-    ref: 0.1.10
+    ref: 0.1.11
 
   - name: gitlab-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-postgres
-    ref: 0.1.10
+    ref: 0.1.11
 
   - name: gitlab
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab
-    ref: 0.1.10
+    ref: 0.1.11
     imports:
       - name: GITLAB_IDAM_ENABLED
         package: software-factory-idam-gitlab

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -3,7 +3,7 @@ kind: UDSBundle
 metadata:
   name: software-factory-demo
   description: A UDS bundle for deploying a software factory to k3d for demonstration purposes NOT FOR PRODUCTION
-  version: 0.0.9
+  version: 0.0.10
   architecture: amd64
 
 packages:

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -3,7 +3,7 @@ kind: UDSBundle
 metadata:
   name: software-factory-demo
   description: A UDS bundle for deploying a software factory to k3d for demonstration purposes NOT FOR PRODUCTION
-  version: 0.0.12
+  version: 0.0.13
   architecture: amd64
 
 packages:
@@ -17,7 +17,7 @@ packages:
   # Defense Unicorns Big Bang Distro
   - name: dubbd-k3d
     repository: ghcr.io/defenseunicorns/packages/dubbd-k3d
-    ref: 0.15.0
+    ref: 0.16.0
 
   # Namespace pre-reqs for swf capabilities
   - name: software-factory-namespaces
@@ -79,19 +79,19 @@ packages:
   # Gitlab
   - name: gitlab-redis
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-redis
-    ref: 0.1.14
+    ref: 0.1.15
 
   - name: gitlab-minio
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-minio
-    ref: 0.1.11
+    ref: 0.1.15
 
   - name: gitlab-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab/dev-dependency/gitlab-postgres
-    ref: 0.1.11
+    ref: 0.1.15
 
   - name: gitlab
     repository: ghcr.io/defenseunicorns/uds-capability/gitlab
-    ref: 0.1.14
+    ref: 0.1.15
     imports:
       - name: GITLAB_IDAM_ENABLED
         package: software-factory-idam-gitlab
@@ -112,11 +112,11 @@ packages:
   # Sonarqube
   - name: sonarqube-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/sonarqube/dev-dependency/sonarqube-postgres
-    ref: 0.1.2
+    ref: 0.1.3
 
   - name: sonarqube
     repository: ghcr.io/defenseunicorns/uds-capability/sonarqube
-    ref: 0.1.2
+    ref: 0.1.3
     imports:
       - name: SONARQUBE_IDAM_ENABLED
         package: software-factory-idam-sonarqube
@@ -136,20 +136,20 @@ packages:
   # Jira
   - name: jira-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/jira/dev-dependency/jira-postgres
-    ref: 0.1.3
+    ref: 0.1.5
 
   - name: jira
     repository: ghcr.io/defenseunicorns/uds-capability/jira
-    ref: 0.1.3
+    ref: 0.1.5
 
   # Confluence
   - name: confluence-postgres
     repository: ghcr.io/defenseunicorns/uds-capability/confluence/dev-dependency/confluence-postgres
-    ref: 0.1.3
+    ref: 0.1.4
 
   - name: confluence
     repository: ghcr.io/defenseunicorns/uds-capability/confluence
-    ref: 0.1.3
+    ref: 0.1.4
 
    # Mattermost Operator with a Mattermost instance
   - name: mattermost-minio

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -1,9 +1,9 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.0.5-alpha/uds.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.5.1/uds.schema.json
 kind: UDSBundle
 metadata:
   name: software-factory-demo
   description: A UDS bundle for deploying a software factory to k3d for demonstration purposes NOT FOR PRODUCTION
-  version: 0.0.10
+  version: 0.0.11
   architecture: amd64
 
 packages:

--- a/uds-config.yaml
+++ b/uds-config.yaml
@@ -1,46 +1,36 @@
-bundle:
-  deploy:
-    zarf-packages:
-      dubbd-k3d:
-        set:
-          DOMAIN: "bigbang.dev"
-      software-factory-idam-gitlab:
-        set:
-          DOMAIN: "bigbang.dev"
-      software-factory-idam-realm:
-        set:
-          DOMAIN: "bigbang.dev"
-      uds-idam:
-        set:
-          DOMAIN: "bigbang.dev"
-      gitlab:
-        set:
-          DOMAIN: "bigbang.dev"
-          GITLAB_DB_NAME: "gitlabdb"
-          GITLAB_DB_USERNAME: "gitlab"
-          GITLAB_PAGES_ENABLED: "false"
-          GITLAB_SIGNUP_ENABLED: "true"
-      sonarqube:
-        set:
-          DOMAIN: "bigbang.dev"
-          SONARQUBE_IDAM_REALM_URL: "https://keycloak.bigbang.dev/auth/realms/baby-yoda"
-          SONARQUBE_DB_NAME: "sonarqubedb"
-          SONARQUBE_DB_USERNAME: "sonarqube"
-      jira:
-        set:
-          DOMAIN: "bigbang.dev"
-          JIRA_DB_NAME: "jiradb"
-          JIRA_DB_USERNAME: "jira"
-      confluence:
-        set:
-          DOMAIN: "bigbang.dev"
-          CONFLUENCE_DB_NAME: "confluencedb"
-          CONFLUENCE_DB_USERNAME: "confluence"
-      mattermost:
-        set:
-          DOMAIN: "bigbang.dev"
-      nexus:
-        set:
-          DOMAIN: "bigbang.dev"
-          NEXUS_DB_NAME: "nexusdb"
-          NEXUS_DB_USERNAME: "nexus"
+options:
+  log_level: info
+variables:
+  dubbd-k3d:
+    DOMAIN: "bigbang.dev"
+  software-factory-idam-gitlab:
+    DOMAIN: "bigbang.dev"
+  software-factory-idam-realm:
+    DOMAIN: "bigbang.dev"
+  uds-idam:
+    DOMAIN: "bigbang.dev"
+  gitlab:
+    DOMAIN: "bigbang.dev"
+    GITLAB_DB_NAME: "gitlabdb"
+    GITLAB_DB_USERNAME: "gitlab"
+    GITLAB_PAGES_ENABLED: "false"
+    GITLAB_SIGNUP_ENABLED: "true"
+  sonarqube:
+    DOMAIN: "bigbang.dev"
+    SONARQUBE_IDAM_REALM_URL: "https://keycloak.bigbang.dev/auth/realms/baby-yoda"
+    SONARQUBE_DB_NAME: "sonarqubedb"
+    SONARQUBE_DB_USERNAME: "sonarqube"
+  jira:
+    DOMAIN: "bigbang.dev"
+    JIRA_DB_NAME: "jiradb"
+    JIRA_DB_USERNAME: "jira"
+  confluence:
+    DOMAIN: "bigbang.dev"
+    CONFLUENCE_DB_NAME: "confluencedb"
+    CONFLUENCE_DB_USERNAME: "confluence"
+  mattermost:
+    DOMAIN: "bigbang.dev"
+  nexus:
+    DOMAIN: "bigbang.dev"
+    NEXUS_DB_NAME: "nexusdb"
+    NEXUS_DB_USERNAME: "nexus"


### PR DESCRIPTION
Adds GitHub action to use our component-generator repo that takes the OSCAL files from the capability repos and combines them into a larger single OSCAL file for a package.

Uses a config file to fill out the OSCAL metadata and to tell it either local OSCAL file paths (none in this case) and/or remote file paths. 

Also updated renovate to track these repo versions and to update the config file.